### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ The development of **League Akari** has been greatly inspired by several outstan
 | [Community Dragon](https://www.communitydragon.org/documentation/assets)                           | Resource management and asset documentation reference.                               |
 | [Seraphine](https://github.com/Zzaphkiel/Seraphine)                                                | Provided integration approaches and insights into combining multiple tools.          |
 | [fix-lcu-window](https://github.com/LeagueTavern/fix-lcu-window)                                   | Resolved the issue with abnormal window size of the League of Legends client.        |
-| [Joi](https://github.com/watchingfun/Joi)                                                          | A League of Legends assistant. tool                                                  |
+| [Joi](https://github.com/watchingfun/Joi)                                                          | A League of Legends assistant tool.                                                  |
 | [vscode-league-respawn-timer](https://github.com/Coooookies/vscode-league-respawn-timer)           | An extension to display League of Legends player respawn time in Visual Studio Code. |
 | [LeaguePrank](https://github.com/LeagueTavern/LeaguePrank)                                         | Provided inspiration for playful and humorous features.                              |
 
@@ -96,6 +96,5 @@ Additionally, **this application is not officially supported or endorsed by Riot
 This disclaimer is intended to provide transparency and enable users to make informed decisions. Thank you for your understanding, and please ensure fair play in the gaming environment.
 
 [![Star History Chart](https://api.star-history.com/svg?repos=Hanxven/LeagueAkari&type=Date)](https://star-history.com/#Hanxven/LeagueAkari&Date)
-
 
 ⚠️ WARNING: This file was auto-modified by a script you ran.


### PR DESCRIPTION
## Summary
- fix minor typo in README

## Testing
- `npx prettier README.md -w`

------
https://chatgpt.com/codex/tasks/task_e_684538a22c9c8330837c630f3d92929e