### PR TITLE
Fix settings array validation

### DIFF
--- a/src/main/shards/setting-factory/index.ts
+++ b/src/main/shards/setting-factory/index.ts
@@ -340,10 +340,13 @@ export class SettingFactoryMain implements IAkariShardInitDispose {
 
     // 检查字段类型
     if (
-      !Array.isArray(content.data) &&
-      content.data.every((v: any) => {
-        typeof v !== 'object' || typeof v.key !== 'string' || v.value !== 'string'
-      })
+      !Array.isArray(content.data) ||
+      !content.data.every(
+        (v: any) =>
+          typeof v === 'object' &&
+          typeof v.key === 'string' &&
+          typeof v.value === 'string'
+      )
     ) {
       throw new AkariIpcError(`The file is not a valid settings file`, 'InvalidSettingsData')
     }


### PR DESCRIPTION
## Summary
- fix settings file array type validation in SettingFactory

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_6845389d185c8330a0fa33cbb44e172c