### PR TITLE
follow league client movement for side windows

### DIFF
--- a/src/main/shards/window-manager/aux-window/state.ts
+++ b/src/main/shards/window-manager/aux-window/state.ts
@@ -7,6 +7,7 @@ export class AuxWindowSettings {
   opacity: number = 1
   pinned: boolean = true
   showSkinSelector: boolean = false
+  snapToGame: boolean = false
 
   setOpacity(opacity: number) {
     this.opacity = opacity
@@ -18,6 +19,10 @@ export class AuxWindowSettings {
 
   setShowSkinSelector(show: boolean) {
     this.showSkinSelector = show
+  }
+
+  setSnapToGame(snapToGame: boolean) {
+    this.snapToGame = snapToGame
   }
 
   setAutoShow(autoShow: boolean) {

--- a/src/main/shards/window-manager/aux-window/window.ts
+++ b/src/main/shards/window-manager/aux-window/window.ts
@@ -5,8 +5,27 @@ import { comparer, computed } from 'mobx'
 
 import { WindowManagerMainContext } from '..'
 import { BaseAkariWindow } from '../base-akari-window'
-import { repositionToAlignLeagueClientUx } from '../position-utils'
+import { getLeagueClientUxBounds, repositionToAlignLeagueClientUx } from '../position-utils'
 import { AuxWindowSettings, AuxWindowState } from './state'
+
+const SNAP_CHECK_INTERVAL = 500
+const POSITION_THRESHOLD = 5
+
+function hasClientBoundsChanged(
+  previous: ReturnType<typeof getLeagueClientUxBounds>,
+  next: NonNullable<ReturnType<typeof getLeagueClientUxBounds>>
+) {
+  if (!previous) {
+    return true
+  }
+
+  return (
+    Math.abs(previous.x - next.x) > POSITION_THRESHOLD ||
+    Math.abs(previous.y - next.y) > POSITION_THRESHOLD ||
+    Math.abs(previous.width - next.width) > POSITION_THRESHOLD ||
+    Math.abs(previous.height - next.height) > POSITION_THRESHOLD
+  )
+}
 
 export class AkariAuxWindow extends BaseAkariWindow<AuxWindowState, AuxWindowSettings> {
   static readonly NAMESPACE_SUFFIX = 'aux-window'
@@ -35,7 +54,8 @@ export class AkariAuxWindow extends BaseAkariWindow<AuxWindowState, AuxWindowSet
       settingSchema: {
         enabled: { default: settings.enabled },
         autoShow: { default: settings.autoShow },
-        showSkinSelector: { default: settings.showSkinSelector }
+        showSkinSelector: { default: settings.showSkinSelector },
+        snapToGame: { default: settings.snapToGame }
       },
       browserWindowOptions: {
         title: AkariAuxWindow.TITLE,
@@ -49,6 +69,30 @@ export class AkariAuxWindow extends BaseAkariWindow<AuxWindowState, AuxWindowSet
   }
 
   private _handleAuxWindowLogics() {
+    let snapIntervalId: NodeJS.Timeout | null = null
+    let lastClientBounds: ReturnType<typeof getLeagueClientUxBounds> = null
+
+    const stopSnap = () => {
+      if (snapIntervalId) {
+        clearInterval(snapIntervalId)
+        snapIntervalId = null
+      }
+    }
+
+    const snapToLeagueClient = () => {
+      if (!this._window || this._window.isDestroyed() || !this.settings.snapToGame || !this.state.show) {
+        return
+      }
+
+      const clientBounds = getLeagueClientUxBounds()
+      if (!clientBounds || !hasClientBoundsChanged(lastClientBounds, clientBounds)) {
+        return
+      }
+
+      lastClientBounds = clientBounds
+      repositionToAlignLeagueClientUx(this._window, 'top-left')
+    }
+
     const showTiming = computed(() => {
       if (!this.settings.autoShow) {
         return 'ignore'
@@ -114,6 +158,31 @@ export class AkariAuxWindow extends BaseAkariWindow<AuxWindowState, AuxWindowSet
       }
     )
 
+    this._mobx.reaction(
+      () => [this.state.show, this.state.ready, this.state.status, this.settings.snapToGame] as const,
+      ([show, ready, status, snapToGame]) => {
+        stopSnap()
+
+        if (show && ready && status !== 'minimized' && snapToGame) {
+          lastClientBounds = null
+          snapToLeagueClient()
+          snapIntervalId = setInterval(snapToLeagueClient, SNAP_CHECK_INTERVAL)
+        }
+      },
+      { fireImmediately: true, equals: comparer.shallow }
+    )
+
+    this._mobx.reaction(
+      () => this._window,
+      (window) => {
+        if (window) {
+          window.once('closed', stopSnap)
+        } else {
+          stopSnap()
+        }
+      }
+    )
+
     // 快速关闭会提供提示
     this._setting._getFromStorage(AkariAuxWindow.QUICK_CLOSE_TIP_STORAGE_KEY).then((tip) => {
       if (!tip) {
@@ -164,6 +233,6 @@ export class AkariAuxWindow extends BaseAkariWindow<AuxWindowState, AuxWindowSet
   }
 
   protected override getSettingPropKeys() {
-    return ['enabled', 'autoShow', 'showSkinSelector'] as const
+    return ['enabled', 'autoShow', 'showSkinSelector', 'snapToGame'] as const
   }
 }

--- a/src/main/shards/window-manager/opgg-window/state.ts
+++ b/src/main/shards/window-manager/opgg-window/state.ts
@@ -7,6 +7,7 @@ export class OpggWindowSettings {
   opacity: number = 1
   pinned: boolean = true
   showShortcut: string | null = null
+  snapToGame: boolean = false
 
   setOpacity(opacity: number) {
     this.opacity = opacity
@@ -22,6 +23,10 @@ export class OpggWindowSettings {
 
   setEnabled(enabled: boolean) {
     this.enabled = enabled
+  }
+
+  setSnapToGame(snapToGame: boolean) {
+    this.snapToGame = snapToGame
   }
 
   setShowShortcut(showShortcut: string | null) {

--- a/src/main/shards/window-manager/opgg-window/window.ts
+++ b/src/main/shards/window-manager/opgg-window/window.ts
@@ -4,8 +4,27 @@ import { comparer, computed } from 'mobx'
 
 import type { WindowManagerMainContext } from '..'
 import { BaseAkariWindow } from '../base-akari-window'
-import { repositionToAlignLeagueClientUx } from '../position-utils'
+import { getLeagueClientUxBounds, repositionToAlignLeagueClientUx } from '../position-utils'
 import { OpggWindowSettings, OpggWindowState } from './state'
+
+const SNAP_CHECK_INTERVAL = 500
+const POSITION_THRESHOLD = 5
+
+function hasClientBoundsChanged(
+  previous: ReturnType<typeof getLeagueClientUxBounds>,
+  next: NonNullable<ReturnType<typeof getLeagueClientUxBounds>>
+) {
+  if (!previous) {
+    return true
+  }
+
+  return (
+    Math.abs(previous.x - next.x) > POSITION_THRESHOLD ||
+    Math.abs(previous.y - next.y) > POSITION_THRESHOLD ||
+    Math.abs(previous.width - next.width) > POSITION_THRESHOLD ||
+    Math.abs(previous.height - next.height) > POSITION_THRESHOLD
+  )
+}
 
 export class AkariOpggWindow extends BaseAkariWindow<OpggWindowState, OpggWindowSettings> {
   static readonly NAMESPACE_SUFFIX = 'opgg-window'
@@ -34,7 +53,8 @@ export class AkariOpggWindow extends BaseAkariWindow<OpggWindowState, OpggWindow
       settingSchema: {
         enabled: { default: settings.enabled },
         autoShow: { default: settings.autoShow },
-        showShortcut: { default: settings.showShortcut }
+        showShortcut: { default: settings.showShortcut },
+        snapToGame: { default: settings.snapToGame }
       },
       browserWindowOptions: {
         title: AkariOpggWindow.TITLE,
@@ -50,6 +70,30 @@ export class AkariOpggWindow extends BaseAkariWindow<OpggWindowState, OpggWindow
   }
 
   private _handleOpggWindowLogics() {
+    let snapIntervalId: NodeJS.Timeout | null = null
+    let lastClientBounds: ReturnType<typeof getLeagueClientUxBounds> = null
+
+    const stopSnap = () => {
+      if (snapIntervalId) {
+        clearInterval(snapIntervalId)
+        snapIntervalId = null
+      }
+    }
+
+    const snapToLeagueClient = () => {
+      if (!this._window || this._window.isDestroyed() || !this.settings.snapToGame || !this.state.show) {
+        return
+      }
+
+      const clientBounds = getLeagueClientUxBounds()
+      if (!clientBounds || !hasClientBoundsChanged(lastClientBounds, clientBounds)) {
+        return
+      }
+
+      lastClientBounds = clientBounds
+      repositionToAlignLeagueClientUx(this._window, 'top-right')
+    }
+
     const showTiming = computed(() => {
       if (!this.settings.autoShow) {
         return 'ignore'
@@ -94,6 +138,31 @@ export class AkariOpggWindow extends BaseAkariWindow<OpggWindowState, OpggWindow
       { fireImmediately: true, delay: 500, equals: comparer.shallow }
     )
 
+    this._mobx.reaction(
+      () => [this.state.show, this.state.ready, this.state.status, this.settings.snapToGame] as const,
+      ([show, ready, status, snapToGame]) => {
+        stopSnap()
+
+        if (show && ready && status !== 'minimized' && snapToGame) {
+          lastClientBounds = null
+          snapToLeagueClient()
+          snapIntervalId = setInterval(snapToLeagueClient, SNAP_CHECK_INTERVAL)
+        }
+      },
+      { fireImmediately: true, equals: comparer.shallow }
+    )
+
+    this._mobx.reaction(
+      () => this._window,
+      (window) => {
+        if (window) {
+          window.once('closed', stopSnap)
+        } else {
+          stopSnap()
+        }
+      }
+    )
+
     this._ipc.onCall(this._namespace, 'repositionToAlignLeagueClientUx', (_, placement) => {
       if (this._window) {
         repositionToAlignLeagueClientUx(this._window, placement)
@@ -136,6 +205,6 @@ export class AkariOpggWindow extends BaseAkariWindow<OpggWindowState, OpggWindow
   }
 
   protected override getSettingPropKeys() {
-    return ['enabled', 'autoShow', 'showShortcut'] as const
+    return ['enabled', 'autoShow', 'showShortcut', 'snapToGame'] as const
   }
 }

--- a/src/main/shards/window-manager/position-utils.ts
+++ b/src/main/shards/window-manager/position-utils.ts
@@ -199,19 +199,33 @@ export function getCenteredRectangle(width: number, height: number) {
   return { x, y, width, height }
 }
 
+export function getLeagueClientUxBounds() {
+  const info = tools.getLeagueClientWindowPlacementInfo()
+  if (!info) {
+    return null
+  }
+
+  const { left, top, width, height } = info
+
+  // League Client Ux 的窗口在最小化时会变为 { x: 0, y: 0, width: 134, height: 37 }
+  if (width < 200 && height < 50) {
+    return null
+  }
+
+  return {
+    x: left,
+    y: top,
+    width,
+    height
+  }
+}
+
 export function repositionToAlignLeagueClientUx(
   win: BrowserWindow,
   placement?: 'top-left' | 'bottom-left' | 'top-right' | 'bottom-right'
 ) {
-  const info = tools.getLeagueClientWindowPlacementInfo()
-  if (info) {
-    const { left, top, width, height } = info
-
-    // League Client Ux 的窗口在最小化时会变为 { x: 0, y: 0, width: 134, height: 37 }
-    if (width < 200 && height < 50) {
-      return
-    }
-
-    repositionWindowWithSnap(win, { x: left, y: top, width, height }, placement)
+  const bounds = getLeagueClientUxBounds()
+  if (bounds) {
+    repositionWindowWithSnap(win, bounds, placement)
   }
 }

--- a/src/renderer-shared/shards/window-manager/index.ts
+++ b/src/renderer-shared/shards/window-manager/index.ts
@@ -78,6 +78,10 @@ class AkariAuxWindow extends BaseAkariWindowRenderer<
     return this._context.setting.set(MAIN_SHARD_NAMESPACE_AUX_WINDOW, 'showSkinSelector', value)
   }
 
+  setSnapToGame(value: boolean) {
+    return this._context.setting.set(MAIN_SHARD_NAMESPACE_AUX_WINDOW, 'snapToGame', value)
+  }
+
   repositionToAlignLeagueClientUx() {
     return this._context.ipc.call(
       MAIN_SHARD_NAMESPACE_AUX_WINDOW,
@@ -112,6 +116,10 @@ export class AkariOpggWindow extends BaseAkariWindowRenderer<
 
   setShowShortcut(value: string | null) {
     return this._context.setting.set(MAIN_SHARD_NAMESPACE_OPGG_WINDOW, 'showShortcut', value)
+  }
+
+  setSnapToGame(value: boolean) {
+    return this._context.setting.set(MAIN_SHARD_NAMESPACE_OPGG_WINDOW, 'snapToGame', value)
   }
 
   repositionToAlignLeagueClientUx() {

--- a/src/renderer-shared/shards/window-manager/store.ts
+++ b/src/renderer-shared/shards/window-manager/store.ts
@@ -54,7 +54,8 @@ export const useAuxWindowStore = defineStore('shard:window-manager-renderer/aux-
     autoShow: true,
     opacity: 0.9,
     pinned: true,
-    showSkinSelector: false
+    showSkinSelector: false,
+    snapToGame: false
   })
 
   const basicWindowState = useBasicWindowStates()
@@ -71,7 +72,8 @@ export const useOpggWindowStore = defineStore('shard:window-manager-renderer/opg
     autoShow: true,
     opacity: 0.9,
     pinned: true,
-    showShortcut: null as string | null
+    showShortcut: null as string | null,
+    snapToGame: false
   })
 
   const basicWindowState = useBasicWindowStates()

--- a/src/renderer/src-main-window/components/settings-modal/MultiWindowSettings.vue
+++ b/src/renderer/src-main-window/components/settings-modal/MultiWindowSettings.vue
@@ -37,6 +37,18 @@
       </ControlItem>
       <ControlItem
         class="control-item-margin"
+        :label="t('MultiWindowSettings.auxWindow.snapToGame.label')"
+        :label-description="t('MultiWindowSettings.auxWindow.snapToGame.description')"
+        :label-width="400"
+      >
+        <NSwitch
+          size="small"
+          :value="aws.settings.snapToGame"
+          @update:value="(val) => wm.auxWindow.setSnapToGame(val)"
+        />
+      </ControlItem>
+      <ControlItem
+        class="control-item-margin"
         :label="t('MultiWindowSettings.auxWindow.opacity.label')"
         :label-description="t('MultiWindowSettings.auxWindow.opacity.description')"
         :label-width="400"
@@ -113,6 +125,18 @@
           size="small"
           :value="ows.settings.autoShow"
           @update:value="(val) => wm.opggWindow.setAutoShow(val)"
+        />
+      </ControlItem>
+      <ControlItem
+        class="control-item-margin"
+        :label="t('MultiWindowSettings.opggWindow.snapToGame.label')"
+        :label-description="t('MultiWindowSettings.opggWindow.snapToGame.description')"
+        :label-width="400"
+      >
+        <NSwitch
+          size="small"
+          :value="ows.settings.snapToGame"
+          @update:value="(val) => wm.opggWindow.setSnapToGame(val)"
         />
       </ControlItem>
       <ControlItem

--- a/src/shared/i18n/en/renderer.yaml
+++ b/src/shared/i18n/en/renderer.yaml
@@ -369,6 +369,10 @@ MultiWindowSettings:
       label: Auto Show and Close
       description: Automatically show or close the auxiliary window during specific game phases.
 
+    snapToGame:
+      label: Follow League Client Movement
+      description: Automatically keep the auxiliary window aligned to the left side of the League Client while it moves.
+
     opacity:
       label: Window Opacity
       description: Adjust the transparency level of the auxiliary window.
@@ -394,6 +398,10 @@ MultiWindowSettings:
     autoShow:
       label: Auto Show and Close
       description: Automatically show or close the OP.GG window during specific game phases.
+
+    snapToGame:
+      label: Follow League Client Movement
+      description: Automatically keep the OP.GG window aligned to the right side of the League Client while it moves.
 
     opacity:
       label: Window Opacity

--- a/src/shared/i18n/zh-CN/renderer.yaml
+++ b/src/shared/i18n/zh-CN/renderer.yaml
@@ -371,6 +371,10 @@ MultiWindowSettings:
       label: 自动弹出和关闭
       description: 在游戏流程的部分阶段，自动弹出或关闭小窗口
 
+    snapToGame:
+      label: 跟随客户端移动
+      description: 当英雄联盟客户端窗口移动时，自动将小窗口重新贴附到客户端左侧
+
     opacity:
       label: 小窗口不透明度
       description: 小窗口的半透明状态
@@ -396,6 +400,10 @@ MultiWindowSettings:
     autoShow:
       label: 自动弹出和关闭
       description: 在游戏流程的部分阶段，自动弹出或关闭 OP.GG 窗口
+
+    snapToGame:
+      label: 跟随客户端移动
+      description: 当英雄联盟客户端窗口移动时，自动将 OP.GG 窗口重新贴附到客户端右侧
 
     opacity:
       label: OP.GG 窗口不透明度


### PR DESCRIPTION
## Summary
- add a follow-client-movement option for the auxiliary window and OP.GG window
- keep both side windows re-snapped while the League Client UX window moves
- expose the new toggle in multi-window settings with zh-CN and en copy

## Validation
- npm run typecheck