### PR TITLE
fix(auto-select): fill fields missing from saved pick/ban configs

### DIFF
--- a/src/main/shards/auto-select/config-manager.test.ts
+++ b/src/main/shards/auto-select/config-manager.test.ts
@@ -1,0 +1,104 @@
+import { runInAction } from 'mobx'
+import { describe, expect, it, vi } from 'vitest'
+
+import { AutoSelectConfigManager } from './config-manager'
+import type { AutoSelectMainContext } from './context'
+import { AutoSelectSettings } from './state'
+
+const GROUP_ID = 'normal'
+
+function createContext(groupIds: string[] = [GROUP_ID]) {
+  const settings = new AutoSelectSettings()
+  const settingService = { set: vi.fn() }
+
+  const context = {
+    settings,
+    settingService,
+    state: {
+      groups: groupIds.map((groupId) => ({ groupId }))
+    }
+  } as unknown as AutoSelectMainContext
+
+  return { context, settings, settingService }
+}
+
+describe('fillAutoBanPickConfig', () => {
+  it('creates a full default config for a group that has none', async () => {
+    const { context, settings } = createContext()
+
+    await new AutoSelectConfigManager(context).fillAutoBanPickConfig()
+
+    expect(settings.pickConfig[GROUP_ID]).toEqual(settings.createNewEmptyPickConfig())
+    expect(settings.banConfig[GROUP_ID]).toEqual(settings.createNewEmptyBanConfig())
+  })
+
+  it('fills a field missing from a saved group without touching its champions', async () => {
+    const { context, settings } = createContext()
+    const { strategy, ...savedPickConfig } = settings.createNewEmptyPickConfig()
+    savedPickConfig.champions.middle = [1, 2, 3]
+
+    runInAction(() => {
+      settings.pickConfig = { [GROUP_ID]: savedPickConfig as typeof savedPickConfig & { strategy } }
+      settings.banConfig = { [GROUP_ID]: settings.createNewEmptyBanConfig() }
+    })
+
+    await new AutoSelectConfigManager(context).fillAutoBanPickConfig()
+
+    expect(settings.pickConfig[GROUP_ID].strategy).toBe('show-and-lock-in')
+    expect(settings.pickConfig[GROUP_ID].champions.middle).toEqual([1, 2, 3])
+  })
+
+  it('keeps saved falsy values instead of overwriting them with defaults', async () => {
+    const { context, settings } = createContext()
+    const savedPickConfig = {
+      ...settings.createNewEmptyPickConfig(),
+      enabled: true,
+      delaySeconds: 0,
+      ignoreIntent: false,
+      benchSwapAccumulatedDelaySeconds: 0
+    }
+    savedPickConfig.champions.top = []
+
+    runInAction(() => {
+      settings.pickConfig = { [GROUP_ID]: savedPickConfig }
+      settings.banConfig = { [GROUP_ID]: settings.createNewEmptyBanConfig() }
+    })
+
+    await new AutoSelectConfigManager(context).fillAutoBanPickConfig()
+
+    expect(settings.pickConfig[GROUP_ID].enabled).toBe(true)
+    expect(settings.pickConfig[GROUP_ID].delaySeconds).toBe(0)
+    expect(settings.pickConfig[GROUP_ID].ignoreIntent).toBe(false)
+    expect(settings.pickConfig[GROUP_ID].benchSwapAccumulatedDelaySeconds).toBe(0)
+    expect(settings.pickConfig[GROUP_ID].champions.top).toEqual([])
+  })
+
+  it('fills a field missing from a saved ban config', async () => {
+    const { context, settings } = createContext()
+    const { strategy, ...savedBanConfig } = settings.createNewEmptyBanConfig()
+    savedBanConfig.champions.default = [10]
+
+    runInAction(() => {
+      settings.pickConfig = { [GROUP_ID]: settings.createNewEmptyPickConfig() }
+      settings.banConfig = { [GROUP_ID]: savedBanConfig as typeof savedBanConfig & { strategy } }
+    })
+
+    await new AutoSelectConfigManager(context).fillAutoBanPickConfig()
+
+    expect(settings.banConfig[GROUP_ID].strategy).toBe('show-and-lock-in')
+    expect(settings.banConfig[GROUP_ID].champions.default).toEqual([10])
+  })
+
+  it('does not persist anything when every group is already complete', async () => {
+    const { context, settings, settingService } = createContext()
+
+    runInAction(() => {
+      settings.pickConfig = { [GROUP_ID]: settings.createNewEmptyPickConfig() }
+      settings.banConfig = { [GROUP_ID]: settings.createNewEmptyBanConfig() }
+    })
+
+    await new AutoSelectConfigManager(context).fillAutoBanPickConfig()
+
+    expect(settingService.set).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/shards/auto-select/config-manager.ts
+++ b/src/main/shards/auto-select/config-manager.ts
@@ -1,6 +1,16 @@
+import _ from 'lodash'
 import { runInAction } from 'mobx'
 
 import type { AutoSelectMainContext } from './context'
+
+/**
+ * 已保存的配置可能缺少后续新增的字段，取其默认值补齐
+ */
+function getMissingDefaults<T extends object>(current: T, defaults: T) {
+  const missing = _.omitBy(defaults, (_value, key) => Object.hasOwn(current, key)) as Partial<T>
+
+  return Object.keys(missing).length ? missing : null
+}
 
 export class AutoSelectConfigManager {
   constructor(private readonly _context: AutoSelectMainContext) {}
@@ -11,14 +21,32 @@ export class AutoSelectConfigManager {
 
     runInAction(() => {
       for (const group of state.groups) {
-        if (!settings.pickConfig[group.groupId]) {
+        const pickConfig = settings.pickConfig[group.groupId]
+
+        if (!pickConfig) {
           modified = true
           settings.setPickConfig(group.groupId, settings.createNewEmptyPickConfig())
+        } else {
+          const missing = getMissingDefaults(pickConfig, settings.createNewEmptyPickConfig())
+
+          if (missing) {
+            modified = true
+            settings.setPickConfig(group.groupId, missing)
+          }
         }
 
-        if (!settings.banConfig[group.groupId]) {
+        const banConfig = settings.banConfig[group.groupId]
+
+        if (!banConfig) {
           modified = true
           settings.setBanConfig(group.groupId, settings.createNewEmptyBanConfig())
+        } else {
+          const missing = getMissingDefaults(banConfig, settings.createNewEmptyBanConfig())
+
+          if (missing) {
+            modified = true
+            settings.setBanConfig(group.groupId, missing)
+          }
         }
       }
     })


### PR DESCRIPTION
Closes #455

## What

`fillAutoBanPickConfig()` now fills top-level fields that are missing from an already-saved group config, taking the values from the empty config. Groups that have no config at all keep being created in full, as before.

## Why

Saved group configs are restored as-is, and a config was only created for a group that was absent entirely. So a group written by an earlier version never gained fields added later: they stayed `undefined` while the config type declares them as required, and only behaved because `undefined` happened to fall through to the intended default.

I ran into this with a `boolean` field I am adding in a separate PR, which was `undefined` on every existing install. The type checker cannot see it.

## Implementation notes

Following the suggestions in #455:

- Both `pickConfig` and `banConfig` are handled.
- Only fields absent from the object itself are filled, via `Object.hasOwn()`. Existing values are never touched — including `false`, `0` and empty arrays, since the check is on key presence, not on the value.
- Only top-level fields are filled; nothing is merged recursively, so an existing `champions` list is never rewritten.
- Nothing is persisted when every group is already complete.

## Verification

New unit tests in `config-manager.test.ts` covering:

- an existing group missing `strategy` (a non-falsy default) gets the default, and its champion list is unchanged;
- the same for a saved ban config;
- saved falsy values (`enabled: true`, `delaySeconds: 0`, `benchSwapAccumulatedDelaySeconds: 0`, empty champion list) survive the fill;
- a group with no config still gets a full default;
- `settingService.set` is not called when there is nothing to fill.

Two of these fail against the current `dev` (`strategy` comes back `undefined`), so they pin the regression rather than just describing it.

`npm run typecheck` and `npm test` are clean (334 tests).

---

*Written with AI assistance (Claude); reviewed by me.*
