### PR TITLE
feat(macos): complete Apple Silicon port

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,30 @@ This section describes how to build League Akari from the source code.
 ## 3.1 Electron Main Program
 
 ```bash
-yarn install
+corepack enable
+yarn install --immutable
 yarn dev
 yarn build:win
 ```
+
+## 3.2 macOS (Apple Silicon)
+
+The current macOS target is Apple Silicon (`arm64`) and uses the Node.js 24 release used by CI.
+
+```bash
+corepack enable
+yarn install --immutable
+yarn typecheck
+yarn test
+yarn build:mac
+```
+
+`yarn build:mac` creates an ARM64 application bundle, DMG, and ZIP under `dist/`. When no Apple
+signing identity is available, the local build is signed ad hoc for testing. Developer ID signing
+and notarization remain available when their standard electron-builder credentials are configured.
+
+See [docs/macos-port-status.md](docs/macos-port-status.md) for installation, logs, verified features,
+and current limitations.
 
 ## Private Packages
 

--- a/docs/macos-port-status.md
+++ b/docs/macos-port-status.md
@@ -1,0 +1,120 @@
+# macOS port status
+
+League Akari currently targets Apple Silicon (`arm64`) on macOS. Intel and universal builds are not
+part of the verified target. The packaged application declares macOS 12.0 as its minimum system
+version.
+
+## Develop and build
+
+Use Node.js 24, matching `.github/workflows/ci-release.yml`, and the checked-in Yarn release:
+
+```bash
+corepack enable
+yarn install --immutable
+yarn dev
+```
+
+Run the complete verification and package build with:
+
+```bash
+yarn typecheck
+yarn test
+yarn build:mac
+```
+
+The macOS build always targets ARM64. Expected outputs are:
+
+- `dist/mac-arm64/League Akari.app`
+- `dist/League Akari-<version>-arm64-mac.zip`
+- `dist/league-akari-<version>.dmg`
+
+The dependency install rebuilds native Node modules for the repository's Electron version. Packaging
+does not rebuild them again, which avoids trying to build the Windows-only native workspace on a Mac.
+
+## Signing and notarization
+
+For a local build without an Apple certificate, `yarn build:mac` selects ad-hoc signing and disables
+the hardened runtime for that local signature. It then verifies the finished bundle with `codesign`.
+This is suitable for local testing, not public distribution.
+
+When `CSC_LINK` or `CSC_NAME` identifies a certificate, or a usable signing identity is present in the
+login keychain, electron-builder performs normal certificate signing with the hardened runtime. Its
+built-in notarization runs when one complete supported credential set is present:
+
+- `APPLE_API_KEY`, `APPLE_API_KEY_ID`, and `APPLE_API_ISSUER`
+- `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, and `APPLE_TEAM_ID`
+- `APPLE_KEYCHAIN_PROFILE`, with optional `APPLE_KEYCHAIN`
+
+Do not place certificates, private keys, or notarization credentials in the repository.
+
+## Install and open
+
+For a DMG, open it and copy **League Akari** to `/Applications`. For a ZIP, extract it and move
+`League Akari.app` to `/Applications`. A locally ad-hoc-signed build can be opened from Finder with
+**Open** in the context menu, or directly during development:
+
+```bash
+open "dist/mac-arm64/League Akari.app"
+```
+
+The packaged app registers the `league-akari` URL scheme. Development builds use
+`league-akari-dev` when started through Electron.
+
+## Logs and credential safety
+
+macOS logs are written to:
+
+```text
+~/Library/Logs/league-akari/LA_<timestamp>.log
+```
+
+Open the directory with:
+
+```bash
+open "$HOME/Library/Logs/league-akari"
+```
+
+Current builds redact Riot Client and LCU authentication values before writing log messages. Tokens
+remain secrets: inspect a log before sharing it, share only the smallest relevant section, and never
+publish logs made by an older build unless credential-bearing command-line arguments and HTTP
+authorization values have been removed. Tests and bug reports must use synthetic credentials.
+
+## Feature matrix
+
+The statuses below describe checks performed on an Apple Silicon Mac for this port. “Untested” means
+the code may be present but the interaction was not manually demonstrated.
+
+The final bundle passed signature, architecture, native-module, ZIP, DMG mount, and packaged GUI
+launch checks. The live smoke check used the real running Riot and League clients without printing
+their credentials.
+
+| Feature                                                                 | Status            | Verification or limitation                                                                                                                                                                                               |
+| ----------------------------------------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| ARM64 application bundle                                                | working           | Packaged executable and Electron framework inspected as ARM64 Mach-O files.                                                                                                                                              |
+| Electron native SQLite module                                           | working           | Packaged `better-sqlite3` loaded in Electron 41 on ARM64 and executed an in-memory query.                                                                                                                                |
+| Packaged startup and main renderer                                      | working           | The final packaged app launched through LaunchServices; its renderer completed loading without a missing-module, Win32-addon, registry, or PowerShell error.                                                             |
+| Running Riot Client and League Client detection                         | working           | The final packaged app discovered the real `RiotClientServices`, `LeagueClient`, and `LeagueClientUx` processes.                                                                                                         |
+| Riot Client and LCU HTTPS connections                                   | working           | Authenticated Riot and LCU renderer probes both returned HTTP 200. TLS exceptions remain scoped to their local clients.                                                                                                  |
+| Core player and match data                                              | working           | The packaged renderer loaded the active summoner, SGP profile, and match-history UI. A cold EUW reload resolved the platform route as `EUW1`, returned the profile, and produced no HTTP 400 response.                   |
+| Filesystem installation discovery                                       | partially working | Default and discovered application paths are supported; non-default installation coverage is fixture-tested rather than exhaustively tested on real installations.                                                       |
+| Riot/League launch from League Akari                                    | partially working | Shell-free bundle/executable selection and argument forwarding pass automated tests. A live already-running invocation did not create duplicate Riot or League processes; a fully closed-client launch remains untested. |
+| Client close/restart reconnection matrix                                | partially working | Startup with both clients already running and the reconnect polling behavior were checked; each requested close/start ordering was not manually exercised.                                                               |
+| Dock activation and reopen                                              | working           | The packaged window was minimized, restored, hidden by close, and reopened through the real app activation handler while the process remained ready.                                                                     |
+| macOS application menu and tray                                         | partially working | A Command-based application menu and template tray icon are implemented; packaged visual behavior was not exhaustively tested.                                                                                           |
+| Single-instance handling                                                | working           | A second packaged invocation was handed to the running instance, restored the main window, and exited without creating duplicate clients.                                                                                |
+| Deep links                                                              | working           | The packaged URL scheme, startup/queued delivery, and a live second-instance `league-akari://` invocation were verified.                                                                                                 |
+| DMG                                                                     | working           | `yarn build:mac` produced the DMG; `hdiutil` verified and mounted it, and the mounted signed ARM64 app plus `/Applications` link were inspected.                                                                         |
+| ZIP                                                                     | working           | ARM64 ZIP produced and inspected; it contains the signed application bundle.                                                                                                                                             |
+| Local ad-hoc signing                                                    | working           | The application bundle passes strict deep `codesign` verification.                                                                                                                                                       |
+| Developer ID signing and notarization                                   | untested          | Credential-aware electron-builder paths are preserved; no signing identity or notarization credentials were available for a live submission.                                                                             |
+| Activation-only global shortcuts                                        | partially working | Electron `globalShortcut` registration and focused-window configuration capture are automated and tested for OP.GG window toggle and cooldown-timer toggle. A physical global-key activation pass remains untested.      |
+| Foreground-only game termination shortcut                               | unsupported       | Safe termination requires foreground-process detection. The control and persisted registration are disabled on macOS rather than terminating every matching background process.                                          |
+| Stateful, last-active, and native shortcut capture                      | unsupported       | Electron cannot preserve the native hook's key-release and active-key-state contracts. Only those affected controls remain gated.                                                                                        |
+| Native global input hook                                                | unsupported       | The Win32 hook is not loaded or packaged on macOS, and dependent controls are capability-gated.                                                                                                                          |
+| Foreground-process detection                                            | unsupported       | The native implementation is Win32-only; dependent behavior is capability-gated.                                                                                                                                         |
+| League Client window placement and resizing                             | unsupported       | The native implementations are Win32-only; only the affected features are capability-gated.                                                                                                                              |
+| Cooldown timer core                                                     | partially working | The timer, supported LCU-driven behavior, and activation-only show/hide shortcut are available. Simulated in-game chat input remains gated because it requires native input.                                             |
+| Hold-key ongoing-game overlay                                           | unsupported       | The overlay's native foreground and held-key contract is unavailable on macOS, so the feature is disabled with a platform explanation.                                                                                   |
+| Windows updater/uninstaller                                             | unsupported       | The Windows executable updater is not started on macOS. Manual replacement with a newer app bundle is required.                                                                                                          |
+| Existing Windows build/runtime                                          | untested          | Windows resources and the native addon are preserved only in Windows packages, and shared TypeScript checks pass. A real Windows package/runtime pass was not possible on this Mac.                                      |
+| Transparent overlays, fullscreen Spaces, and click-through combinations | untested          | No claim is made without a complete manual multi-Space/fullscreen interaction pass.                                                                                                                                      |

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -3,6 +3,7 @@ productName: League Akari
 directories:
   buildResources: build
 files:
+  - '**/*'
   - '!**/.vscode/*'
   - '!src{,/**}'
   - '!electron.vite.config.{js,ts,mjs,cjs}'
@@ -28,8 +29,13 @@ files:
   - '!node_modules/better-sqlite3/{deps,src}{,/**}'
   - '!node_modules/better-sqlite3/{binding.gyp,*.gypi}'
   - '!node_modules/better-sqlite3/build/Release/{.forge-meta,obj}{,/**}'
-  - '!node_modules/league-akari-native-win32/{build,lib,scripts,node_modules}{,/**}'
-  - '!node_modules/league-akari-native-win32/{binding.gyp,tsconfig.json,*.tsbuildinfo}'
+  - '!node_modules/league-akari-native-win32{,/**}'
+  - '!node_modules/regedit{,/**}'
+  - '!resources/magic/*.node'
+  - '!resources/akari-updater.exe'
+  - '!resources/elevate.exe'
+  - '!resources/rebuild_WMI.bat'
+  - '!resources/regedit-vbs{,/**}'
 
 electronLanguages:
   - zh-CN
@@ -42,17 +48,48 @@ afterSign: ./scripts/macos/ensure-codesign.cjs
 asarUnpack:
   - resources/**
 win:
+  files:
+    - from: resources
+      to: resources
+      filter:
+        - akari-updater.exe
+        - elevate.exe
+        - rebuild_WMI.bat
+        - regedit-vbs/**/*
+    - from: resources/magic
+      to: resources/magic
+      filter:
+        - magic.win32-x64.node
+    - from: native/win32-x64
+      to: node_modules/league-akari-native-win32
+      filter:
+        - package.json
+        - dist/**/*
+        - addons/*.node
+    - from: node_modules/regedit
+      to: node_modules/regedit
+      filter:
+        - '**/*'
   target:
     - 7z
   executableName: LeagueAkari
   icon: resources/LA_ICON.ico
 
 mac:
+  files:
+    - from: resources/magic
+      to: resources/magic
+      filter:
+        - magic.darwin-arm64.node
   target:
     - dmg
     - zip
   category: public.app-category.utilities
   icon: build/icon.png
+  protocols:
+    - name: League Akari
+      schemes:
+        - league-akari
 dmg:
   artifactName: ${name}-${version}.${ext}
 asar: true

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build:win": "npm run build && electron-builder --win --config",
     "build:win:native": "npm run build:native:win && npm run build:win",
     "gen-types": "tsc --declaration --emitDeclarationOnly --outDir ./out/types -p tsconfig.node.json",
-    "build:mac": "npm run build && electron-builder --mac --config"
+    "build:mac": "npm run build && node scripts/macos/build.cjs"
   },
   "dependencies": {
     "@babel/runtime": "^8.0.0",

--- a/scripts/macos/build.cjs
+++ b/scripts/macos/build.cjs
@@ -1,0 +1,91 @@
+/* eslint-disable no-console */
+const { spawnSync } = require('node:child_process')
+
+const ACCEPTED_KEYCHAIN_IDENTITIES = [
+  'Developer ID Application:',
+  '3rd Party Mac Developer Application:',
+  'Mac Developer:'
+]
+
+function hasExplicitSigningIdentity(env = process.env) {
+  return Boolean(env.CSC_LINK || (env.CSC_NAME && env.CSC_NAME !== '-'))
+}
+
+function hasUsableKeychainIdentity() {
+  const result = spawnSync('security', ['find-identity', '-v', '-p', 'codesigning'], {
+    encoding: 'utf8'
+  })
+
+  if (result.error || result.status !== 0) {
+    return false
+  }
+
+  return ACCEPTED_KEYCHAIN_IDENTITIES.some((identity) => result.stdout.includes(identity))
+}
+
+function shouldUseAdHocSigning(env = process.env) {
+  if (env.CSC_NAME === '-') {
+    return true
+  }
+
+  if (hasExplicitSigningIdentity(env)) {
+    return false
+  }
+
+  if (env.CSC_IDENTITY_AUTO_DISCOVERY === 'false') {
+    return true
+  }
+
+  return !hasUsableKeychainIdentity()
+}
+
+function buildElectronBuilderArgs(useAdHocSigning, extraArgs = []) {
+  const args = ['--mac', '--arm64', '--config']
+
+  if (useAdHocSigning) {
+    args.push('--config.mac.identity=-', '--config.mac.hardenedRuntime=false')
+  }
+
+  return [...args, ...extraArgs]
+}
+
+function run() {
+  if (process.platform !== 'darwin') {
+    throw new Error('The macOS package must be built on macOS')
+  }
+
+  const useAdHocSigning = shouldUseAdHocSigning()
+  if (useAdHocSigning) {
+    console.log('[macos-build] No signing identity found; using an ad-hoc local signature')
+  } else {
+    console.log('[macos-build] Using the configured or keychain signing identity')
+  }
+
+  const electronBuilderCli = require.resolve('electron-builder/out/cli/cli.js')
+  const result = spawnSync(
+    process.execPath,
+    [electronBuilderCli, ...buildElectronBuilderArgs(useAdHocSigning, process.argv.slice(2))],
+    { stdio: 'inherit' }
+  )
+
+  if (result.error) {
+    throw result.error
+  }
+
+  process.exitCode = result.status ?? 1
+}
+
+if (require.main === module) {
+  try {
+    run()
+  } catch (error) {
+    console.error(error)
+    process.exitCode = 1
+  }
+}
+
+module.exports = {
+  buildElectronBuilderArgs,
+  hasExplicitSigningIdentity,
+  shouldUseAdHocSigning
+}

--- a/scripts/macos/ensure-codesign.cjs
+++ b/scripts/macos/ensure-codesign.cjs
@@ -9,17 +9,30 @@ function run(cmd, args) {
   return res.status ?? 1
 }
 
+function inspectSignature(appPath) {
+  const result = spawnSync('codesign', ['--display', '--verbose=4', appPath], {
+    encoding: 'utf8'
+  })
+
+  return {
+    status: result.status ?? 1,
+    output: `${result.stdout || ''}\n${result.stderr || ''}`
+  }
+}
+
+function hasNamedSigningAuthority(signatureOutput) {
+  return /^Authority=.+$/m.test(signatureOutput)
+}
+
 function ensureCodesign(appPath) {
   if (process.platform !== 'darwin') return
 
   if (!appPath) {
-    console.error('Usage: node scripts/macos/ensure-codesign.cjs "<path-to-app>"')
-    process.exit(2)
+    throw new Error('Usage: node scripts/macos/ensure-codesign.cjs "<path-to-app>"')
   }
 
   if (!fs.existsSync(appPath)) {
-    console.error(`App not found: ${appPath}`)
-    process.exit(2)
+    throw new Error(`App not found: ${appPath}`)
   }
 
   // When electron-builder can't sign (no identity), but Electron fuses are enabled,
@@ -33,23 +46,44 @@ function ensureCodesign(appPath) {
     return
   }
 
+  const signature = inspectSignature(appPath)
+  if (signature.status === 0 && hasNamedSigningAuthority(signature.output)) {
+    throw new Error(
+      '[ensure-codesign] A named signing identity produced an invalid bundle; refusing to replace it with an ad-hoc signature'
+    )
+  }
+
   console.log('[ensure-codesign] codesign verify failed; applying ad-hoc signature...')
   const signStatus = run('codesign', ['--force', '--deep', '--sign', '-', appPath])
-  if (signStatus !== 0) process.exit(signStatus)
+  if (signStatus !== 0) {
+    throw new Error(`[ensure-codesign] Ad-hoc signing failed with exit code ${signStatus}`)
+  }
 
   const verify2Status = run('codesign', verifyArgs)
-  if (verify2Status !== 0) process.exit(verify2Status)
+  if (verify2Status !== 0) {
+    throw new Error(
+      `[ensure-codesign] Ad-hoc signature verification failed with exit code ${verify2Status}`
+    )
+  }
 
   console.log('[ensure-codesign] ad-hoc signature applied and verified')
 }
 
 module.exports = async function ensureCodesignHook(context) {
-  if (process.platform !== 'darwin') return
+  if (process.platform !== 'darwin' || context.electronPlatformName !== 'darwin') return
 
   const productFilename = context.packager.appInfo.productFilename
   ensureCodesign(path.join(context.appOutDir, `${productFilename}.app`))
 }
 
 if (require.main === module) {
-  ensureCodesign(process.argv[2])
+  try {
+    ensureCodesign(process.argv[2])
+  } catch (error) {
+    console.error(error)
+    process.exitCode = 1
+  }
 }
+
+module.exports.ensureCodesign = ensureCodesign
+module.exports.hasNamedSigningAuthority = hasNamedSigningAuthority

--- a/src/main/bootstrap/app-lifecycle.test.ts
+++ b/src/main/bootstrap/app-lifecycle.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'vitest'
+
+import { getDeepLinkArgument, isDeepLinkUrl, shouldQuitWhenAllWindowsClosed } from './app-lifecycle'
+
+describe('macOS application lifecycle', () => {
+  test('keeps the application alive when its last window closes on macOS', () => {
+    expect(shouldQuitWhenAllWindowsClosed('darwin')).toBe(false)
+    expect(shouldQuitWhenAllWindowsClosed('win32')).toBe(true)
+  })
+
+  test('accepts only the configured deep-link protocol', () => {
+    expect(
+      isDeepLinkUrl('league-akari://shards/client-installation-main/launch', 'league-akari')
+    ).toBe(true)
+    expect(
+      isDeepLinkUrl('league-akari-dev://shards/client-installation-main/launch', 'league-akari')
+    ).toBe(false)
+    expect(isDeepLinkUrl('not a URL', 'league-akari')).toBe(false)
+  })
+
+  test('extracts a deep link without depending on its argument position', () => {
+    expect(
+      getDeepLinkArgument(
+        [
+          '/Applications/League Akari.app/Contents/MacOS/League Akari',
+          '--flag',
+          'league-akari://shards/client-installation-main/launch-riot-client-lol'
+        ],
+        'league-akari'
+      )
+    ).toBe('league-akari://shards/client-installation-main/launch-riot-client-lol')
+  })
+})

--- a/src/main/bootstrap/app-lifecycle.ts
+++ b/src/main/bootstrap/app-lifecycle.ts
@@ -1,0 +1,19 @@
+export function isDeepLinkUrl(value: unknown, protocol: string) {
+  if (typeof value !== 'string') {
+    return false
+  }
+
+  try {
+    return new URL(value).protocol === `${protocol}:`
+  } catch {
+    return false
+  }
+}
+
+export function getDeepLinkArgument(argv: string[], protocol: string) {
+  return argv.find((argument) => isDeepLinkUrl(argument, protocol)) ?? null
+}
+
+export function shouldQuitWhenAllWindowsClosed(platform: NodeJS.Platform = process.platform) {
+  return platform !== 'darwin'
+}

--- a/src/main/bootstrap/index.ts
+++ b/src/main/bootstrap/index.ts
@@ -49,6 +49,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { Logger } from 'winston'
 
+import { getDeepLinkArgument, isDeepLinkUrl, shouldQuitWhenAllWindowsClosed } from './app-lifecycle'
 import { readBaseConfig, writeBaseConfig } from './base-config'
 
 interface AkariAppEventMap {
@@ -274,6 +275,7 @@ export function bootstrap() {
     manager.global.isElevated = isElevated
     manager.global.platform = os.platform() as 'darwin' | 'win32'
     manager.global.version = app.getVersion()
+    manager.global.startupDeepLink = null
     manager.global.isWindows11_22H2_OrHigher = isWindows11_22H2_OrHigher()
     manager.global.isReadyToQuit = false
     manager.global.quit = () => app.quit()
@@ -361,18 +363,46 @@ export function bootstrap() {
       app.setAsDefaultProtocolClient(DEEP_LINK_PROTOCOL)
     }
 
-    const getDeepLinkArg = (argv: string[]) => {
-      const urlArg = argv.find(
-        (a) => typeof a === 'string' && a.startsWith(`${DEEP_LINK_PROTOCOL}://`)
-      )
-
-      return urlArg || null
-    }
-
-    const deepLinkArg = getDeepLinkArg(process.argv)
+    const deepLinkArg = getDeepLinkArgument(process.argv, DEEP_LINK_PROTOCOL)
     if (deepLinkArg) {
       manager.global.startupDeepLink = deepLinkArg
     }
+
+    let featureLifecycleStarting = false
+    let featureLifecycleReady = false
+    const pendingDeepLinks: string[] = []
+    const dispatchDeepLink = (url: string) => {
+      if (!isDeepLinkUrl(url, DEEP_LINK_PROTOCOL)) {
+        return
+      }
+
+      if (!featureLifecycleReady) {
+        if (featureLifecycleStarting) {
+          if (manager.global.startupDeepLink !== url) {
+            pendingDeepLinks.push(url)
+          }
+          return
+        }
+
+        if (!manager.global.startupDeepLink) {
+          manager.global.startupDeepLink = url
+        } else if (manager.global.startupDeepLink !== url) {
+          pendingDeepLinks.push(url)
+        }
+        return
+      }
+
+      events.emit('second-instance-deep-link', url)
+    }
+
+    app.on('open-url', (event, url) => {
+      if (!isDeepLinkUrl(url, DEEP_LINK_PROTOCOL)) {
+        return
+      }
+
+      event.preventDefault()
+      dispatchDeepLink(url)
+    })
 
     app.on('second-instance', (_event, commandLine, workingDirectory) => {
       events.emit('second-instance', commandLine, workingDirectory)
@@ -382,15 +412,17 @@ export function bootstrap() {
         namespace: 'app'
       })
 
-      const deepLinkArg = getDeepLinkArg(commandLine)
+      const deepLinkArg = getDeepLinkArgument(commandLine, DEEP_LINK_PROTOCOL)
       if (deepLinkArg) {
-        events.emit('second-instance-deep-link', deepLinkArg)
+        dispatchDeepLink(deepLinkArg)
       }
     })
 
     // 建立在如下假设：主窗口永远不会关闭（而是隐藏）
     app.on('window-all-closed', () => {
-      app.quit()
+      if (shouldQuitWhenAllWindowsClosed()) {
+        app.quit()
+      }
     })
 
     app.on('before-quit', () => {
@@ -401,13 +433,19 @@ export function bootstrap() {
       const wm = manager.getInstance(WindowManagerMain.id) as WindowManagerMain
 
       if (wm) {
+        wm.mainWindow.createWindow()
         wm.mainWindow.showOrRestore()
       }
     })
 
     app.whenReady().then(async () => {
       try {
+        featureLifecycleStarting = true
         await manager.setup()
+        featureLifecycleReady = true
+        for (const pendingDeepLink of pendingDeepLinks.splice(0)) {
+          events.emit('second-instance-deep-link', pendingDeepLink)
+        }
         logShardInitializationReport(logger, manager)
       } catch (error) {
         logShardInitializationReport(logger, manager)

--- a/src/main/logger/index.ts
+++ b/src/main/logger/index.ts
@@ -1,3 +1,4 @@
+import { redactSecretsInString } from '@shared/utils/redact-secrets'
 import dayjs from 'dayjs'
 import { app } from 'electron'
 import fs from 'node:fs'
@@ -92,7 +93,7 @@ export function initAppLogger(level: string = 'info') {
     format: format.combine(
       format.timestamp(),
       format.printf(({ level, message, namespace, timestamp }) => {
-        return `[${dayjs(timestamp as number).format('YYYY-MM-DD HH:mm:ss:SSS')}] [${namespace}] [${level}] ${message}`
+        return `[${dayjs(timestamp as number).format('YYYY-MM-DD HH:mm:ss:SSS')}] [${namespace}] [${level}] ${redactSecretsInString(String(message))}`
       })
     )
   })
@@ -107,7 +108,7 @@ export function initAppLogger(level: string = 'info') {
         const levelColor = LEVEL_COLORS[level] || STYLES.reset
         const levelColored = `${levelColor}[${level}]${STYLES.reset}`
 
-        return `${timestampColored} ${namespaceColored} ${levelColored} ${message}`
+        return `${timestampColored} ${namespaceColored} ${levelColored} ${redactSecretsInString(String(message))}`
       })
     )
   })

--- a/src/main/native/capabilities.test.ts
+++ b/src/main/native/capabilities.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveNativeSupport } from './capabilities'
+
+describe('resolveNativeSupport', () => {
+  it('reports Win32-only capabilities as unsupported on macOS', () => {
+    const support = resolveNativeSupport({
+      platform: 'darwin',
+      isElevated: true,
+      nativeInputAddonLoaded: false,
+      nativeInputInstalled: false
+    })
+
+    expect(support).toEqual({
+      nativeInput: {
+        available: false,
+        availableOnCurrentPlatform: false,
+        requiresElevation: true
+      },
+      activationShortcut: {
+        available: true,
+        availableOnCurrentPlatform: true,
+        requiresElevation: false
+      },
+      getLeagueClientWindowPlacement: {
+        available: false,
+        availableOnCurrentPlatform: false,
+        requiresElevation: false
+      },
+      adjustLeagueClientWindowSize: {
+        available: false,
+        availableOnCurrentPlatform: false,
+        requiresElevation: true
+      },
+      isProcessForeground: {
+        available: false,
+        availableOnCurrentPlatform: false,
+        requiresElevation: true
+      }
+    })
+  })
+
+  it('distinguishes elevation from platform support on Windows', () => {
+    const support = resolveNativeSupport({
+      platform: 'win32',
+      isElevated: false,
+      nativeInputAddonLoaded: true,
+      nativeInputInstalled: false
+    })
+
+    expect(support.nativeInput).toEqual({
+      available: false,
+      availableOnCurrentPlatform: true,
+      requiresElevation: true
+    })
+    expect(support.activationShortcut).toEqual({
+      available: false,
+      availableOnCurrentPlatform: true,
+      requiresElevation: true
+    })
+    expect(support.getLeagueClientWindowPlacement.available).toBe(true)
+    expect(support.adjustLeagueClientWindowSize.available).toBe(false)
+    expect(support.isProcessForeground.available).toBe(false)
+  })
+
+  it('reports installed elevated Windows capabilities as available', () => {
+    const support = resolveNativeSupport({
+      platform: 'win32',
+      isElevated: true,
+      nativeInputAddonLoaded: true,
+      nativeInputInstalled: true
+    })
+
+    expect(Object.values(support).every((capability) => capability.available)).toBe(true)
+  })
+
+  it('does not report activation shortcuts on unsupported platforms', () => {
+    const support = resolveNativeSupport({
+      platform: 'linux',
+      isElevated: false,
+      nativeInputAddonLoaded: false,
+      nativeInputInstalled: false
+    })
+
+    expect(support.activationShortcut).toEqual({
+      available: false,
+      availableOnCurrentPlatform: false,
+      requiresElevation: false
+    })
+  })
+})

--- a/src/main/native/capabilities.ts
+++ b/src/main/native/capabilities.ts
@@ -1,0 +1,46 @@
+import type { NativeSupport } from '@shared/types/common'
+
+export interface NativeSupportRuntime {
+  platform: NodeJS.Platform
+  isElevated: boolean
+  nativeInputAddonLoaded: boolean
+  nativeInputInstalled: boolean
+}
+
+export function resolveNativeSupport(runtime: NativeSupportRuntime): NativeSupport {
+  const isWindows = runtime.platform === 'win32'
+  const isMacOS = runtime.platform === 'darwin'
+  const nativeInputAvailable =
+    isWindows &&
+    runtime.nativeInputAddonLoaded &&
+    runtime.nativeInputInstalled &&
+    runtime.isElevated
+
+  return {
+    nativeInput: {
+      available: nativeInputAvailable,
+      availableOnCurrentPlatform: isWindows,
+      requiresElevation: true
+    },
+    activationShortcut: {
+      available: isMacOS || nativeInputAvailable,
+      availableOnCurrentPlatform: isMacOS || isWindows,
+      requiresElevation: isWindows
+    },
+    getLeagueClientWindowPlacement: {
+      available: isWindows,
+      availableOnCurrentPlatform: isWindows,
+      requiresElevation: false
+    },
+    adjustLeagueClientWindowSize: {
+      available: isWindows && runtime.isElevated,
+      availableOnCurrentPlatform: isWindows,
+      requiresElevation: true
+    },
+    isProcessForeground: {
+      available: isWindows && runtime.isElevated,
+      availableOnCurrentPlatform: isWindows,
+      requiresElevation: true
+    }
+  }
+}

--- a/src/main/native/index.ts
+++ b/src/main/native/index.ts
@@ -1,7 +1,7 @@
-import { NativeSupport } from '@shared/types/common'
 import { getuid } from 'node:process'
 
 import { addons } from './addons-win32'
+import { resolveNativeSupport } from './capabilities'
 import { NotSupportedPlatformError } from './errors'
 import {
   getCommandLinePosix,
@@ -11,7 +11,7 @@ import {
 } from './process-utils-darwin'
 import { getCommandLinePowershell } from './process-utils-win32'
 
-export type { KeyEvent as NativeInputKeyEvent } from 'league-akari-native-win32/input'
+export type { NativeInputKeyEvent } from './types'
 export { magic } from './magic'
 
 /**
@@ -136,25 +136,9 @@ export function getLeagueClientWindowPlacement() {
  */
 export const nativeInput = addons?.input
 
-export const NATIVE_SUPPORT: NativeSupport = {
-  nativeInput: {
-    available: Boolean(nativeInput?.instance.isInstalled) && isElevated,
-    availableOnCurrentPlatform: Boolean(nativeInput),
-    requiresElevation: true
-  },
-  getLeagueClientWindowPlacement: {
-    available: process.platform === 'win32',
-    availableOnCurrentPlatform: process.platform === 'win32',
-    requiresElevation: false
-  },
-  adjustLeagueClientWindowSize: {
-    available: process.platform === 'win32' && isElevated,
-    availableOnCurrentPlatform: process.platform === 'win32',
-    requiresElevation: true
-  },
-  isProcessForeground: {
-    available: process.platform === 'win32' && isElevated,
-    availableOnCurrentPlatform: process.platform === 'win32',
-    requiresElevation: true
-  }
-}
+export const NATIVE_SUPPORT = resolveNativeSupport({
+  platform: process.platform,
+  isElevated,
+  nativeInputAddonLoaded: Boolean(nativeInput),
+  nativeInputInstalled: Boolean(nativeInput?.instance.isInstalled)
+})

--- a/src/main/native/magic.test.ts
+++ b/src/main/native/magic.test.ts
@@ -1,0 +1,30 @@
+import os from 'node:os'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { resolveMagicAddonPath } from './magic'
+
+describe('resolveMagicAddonPath', () => {
+  const baseDir = path.join(os.tmpdir(), 'app.asar', 'out', 'main')
+
+  it('selects only the Apple Silicon addon for an Apple Silicon macOS runtime', () => {
+    expect(resolveMagicAddonPath('darwin', 'arm64', baseDir)).toBe(
+      path
+        .join(baseDir, '../../resources/magic/magic.darwin-arm64.node')
+        .replace('app.asar', 'app.asar.unpacked')
+    )
+  })
+
+  it('preserves the existing Win32 x64 addon selection', () => {
+    expect(resolveMagicAddonPath('win32', 'x64', baseDir)).toBe(
+      path
+        .join(baseDir, '../../resources/magic/magic.win32-x64.node')
+        .replace('app.asar', 'app.asar.unpacked')
+    )
+  })
+
+  it('does not select a native addon for unsupported platform and architecture pairs', () => {
+    expect(resolveMagicAddonPath('darwin', 'x64', baseDir)).toBeNull()
+    expect(resolveMagicAddonPath('linux', 'arm64', baseDir)).toBeNull()
+  })
+})

--- a/src/main/native/magic.ts
+++ b/src/main/native/magic.ts
@@ -1,5 +1,4 @@
-import darwinArm64Path from '@resources/magic/magic.darwin-arm64.node?asset&asarUnpack'
-import win32X64Path from '@resources/magic/magic.win32-x64.node?asset&asarUnpack'
+import path from 'node:path'
 
 interface MagicAddon {
   magic: (value: string) => string
@@ -7,14 +6,30 @@ interface MagicAddon {
 
 let addon: MagicAddon | null | undefined
 
+export function resolveMagicAddonPath(
+  platform: NodeJS.Platform,
+  architecture: string,
+  baseDir: string
+) {
+  const addonFilename =
+    platform === 'win32' && architecture === 'x64'
+      ? 'magic.win32-x64.node'
+      : platform === 'darwin' && architecture === 'arm64'
+        ? 'magic.darwin-arm64.node'
+        : null
+
+  if (!addonFilename) {
+    return null
+  }
+
+  return path
+    .join(baseDir, '../../resources/magic', addonFilename)
+    .replace('app.asar', 'app.asar.unpacked')
+}
+
 export function magic(value: string) {
   if (addon === undefined) {
-    const addonPath =
-      process.platform === 'win32' && process.arch === 'x64'
-        ? win32X64Path
-        : process.platform === 'darwin' && process.arch === 'arm64'
-          ? darwinArm64Path
-          : null
+    const addonPath = resolveMagicAddonPath(process.platform, process.arch, __dirname)
 
     try {
       addon = addonPath ? (require(addonPath) as MagicAddon) : null

--- a/src/main/native/process-command-line.test.ts
+++ b/src/main/native/process-command-line.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  getProcessCommandLineOption,
+  parseProcessCommandLineOptions,
+  redactClientCommandLine
+} from './process-command-line'
+
+describe('process command-line parsing', () => {
+  test('preserves spaced macOS argv values until the next long option', () => {
+    const commandLine =
+      '/Applications/League of Legends.app/Contents/MacOS/LeagueClientUx ' +
+      '--app-port=54321 --install-directory=/Applications/League of Legends.app/Contents/LoL ' +
+      '--app-directory="/Applications/League of Legends.app/Contents/LoL/League of Legends.app"'
+
+    expect(getProcessCommandLineOption(commandLine, 'app-port')).toBe('54321')
+    expect(getProcessCommandLineOption(commandLine, 'install-directory')).toBe(
+      '/Applications/League of Legends.app/Contents/LoL'
+    )
+    expect(getProcessCommandLineOption(commandLine, 'app-directory')).toBe(
+      '/Applications/League of Legends.app/Contents/LoL/League of Legends.app'
+    )
+  })
+
+  test('supports options separated from values by whitespace', () => {
+    const options = parseProcessCommandLineOptions(
+      'LeagueClientUx --app-port 54321 --region "EUW" --feature-flag'
+    )
+
+    expect(options.map(({ name, value }) => ({ name, value }))).toEqual([
+      { name: 'app-port', value: '54321' },
+      { name: 'region', value: 'EUW' },
+      { name: 'feature-flag', value: null }
+    ])
+  })
+
+  test('redacts LCU and Riot credentials while retaining diagnostic options', () => {
+    const commandLine =
+      'LeagueClientUx --app-port=54321 --remoting-auth-token=synthetic-lcu-secret ' +
+      '--riotclient-auth-token "synthetic-riot-secret" ' +
+      '--endpoint=https://riot:synthetic-url-secret@127.0.0.1:54321'
+
+    const redacted = redactClientCommandLine(commandLine)
+
+    expect(redacted).not.toContain('synthetic-lcu-secret')
+    expect(redacted).not.toContain('synthetic-riot-secret')
+    expect(redacted).not.toContain('synthetic-url-secret')
+    expect(redacted).toContain('--app-port=54321')
+    expect(redacted.match(/<redacted>/g)).toHaveLength(3)
+  })
+})

--- a/src/main/native/process-command-line.ts
+++ b/src/main/native/process-command-line.ts
@@ -1,0 +1,94 @@
+import { redactSecretsInString } from '@shared/utils/redact-secrets'
+
+export interface ProcessCommandLineOption {
+  name: string
+  value: string | null
+  start: number
+  end: number
+  valueStart: number | null
+  valueEnd: number | null
+}
+
+const OPTION_START_REGEX = /(^|\s)(--[A-Za-z0-9][A-Za-z0-9_-]*)(?==|\s|$)/g
+
+function stripMatchingQuotes(value: string) {
+  if (value.length < 2) {
+    return value
+  }
+
+  const first = value[0]
+  const last = value[value.length - 1]
+  if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+    return value.slice(1, -1)
+  }
+
+  return value
+}
+
+/**
+ * Parses long command-line options from the process text returned by `ps` or WMI.
+ *
+ * macOS `ps` does not re-quote argv values. Consequently a path such as
+ * `--install-directory=/Applications/League of Legends.app` must be read until the next option,
+ * rather than until the next space.
+ */
+export function parseProcessCommandLineOptions(commandLine: string): ProcessCommandLineOption[] {
+  const matches = Array.from(commandLine.matchAll(OPTION_START_REGEX))
+
+  return matches.map((match, index) => {
+    const leadingWhitespaceLength = match[1].length
+    const start = (match.index ?? 0) + leadingWhitespaceLength
+    const name = match[2].slice(2).toLowerCase()
+    const optionNameEnd = start + match[2].length
+    const nextOptionStart =
+      index + 1 < matches.length
+        ? (matches[index + 1].index ?? commandLine.length) + matches[index + 1][1].length
+        : commandLine.length
+
+    let valueStart = optionNameEnd
+    if (commandLine[valueStart] === '=') {
+      valueStart += 1
+    } else {
+      while (valueStart < nextOptionStart && /\s/.test(commandLine[valueStart])) {
+        valueStart += 1
+      }
+    }
+
+    let valueEnd = nextOptionStart
+    while (valueEnd > valueStart && /\s/.test(commandLine[valueEnd - 1])) {
+      valueEnd -= 1
+    }
+
+    const hasValue = valueStart < valueEnd
+
+    return {
+      name,
+      value: hasValue ? stripMatchingQuotes(commandLine.slice(valueStart, valueEnd)) : null,
+      start,
+      end: valueEnd,
+      valueStart: hasValue ? valueStart : null,
+      valueEnd: hasValue ? valueEnd : null
+    }
+  })
+}
+
+export function getProcessCommandLineOption(
+  commandLine: string,
+  optionNames: string | readonly string[]
+) {
+  const names = new Set(
+    (typeof optionNames === 'string' ? [optionNames] : optionNames).map((name) =>
+      name.replace(/^--/, '').toLowerCase()
+    )
+  )
+
+  return parseProcessCommandLineOptions(commandLine).find((option) => names.has(option.name))?.value
+}
+
+/**
+ * Removes local-client credentials without changing the rest of the command enough to make a log
+ * or diagnostic useless. The return value is safe to log; the input is not.
+ */
+export function redactClientCommandLine(commandLine: string) {
+  return redactSecretsInString(commandLine)
+}

--- a/src/main/native/process-utils-darwin.test.ts
+++ b/src/main/native/process-utils-darwin.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'vitest'
+
+import { findPidsByNamePosix, parsePosixProcessList } from './process-utils-darwin'
+
+describe('Darwin process-list parsing', () => {
+  test('parses executable paths containing spaces and ignores malformed rows', () => {
+    const processes = parsePosixProcessList(`
+      101 /Users/Shared/Riot Games/Riot Client.app/Contents/MacOS/RiotClientServices
+      202 /Applications/League of Legends.app/Contents/LoL/League of Legends.app/Contents/MacOS/LeagueClientUx
+      invalid row
+      0 /usr/bin/invalid
+    `)
+
+    expect(processes).toEqual([
+      {
+        pid: 101,
+        executablePath:
+          '/Users/Shared/Riot Games/Riot Client.app/Contents/MacOS/RiotClientServices',
+        name: 'RiotClientServices'
+      },
+      {
+        pid: 202,
+        executablePath:
+          '/Applications/League of Legends.app/Contents/LoL/League of Legends.app/Contents/MacOS/LeagueClientUx',
+        name: 'LeagueClientUx'
+      }
+    ])
+  })
+
+  test('matches case-insensitively and accepts Windows process aliases', () => {
+    const processes = parsePosixProcessList(`
+      101 /Applications/LeagueClientUx
+      202 /Applications/LeagueClientUx
+      303 /Applications/LeagueClient
+    `)
+
+    expect(findPidsByNamePosix(processes, 'leagueclientux.exe')).toEqual([101, 202])
+    expect(findPidsByNamePosix(processes, 'LeagueClient.exe')).toEqual([303])
+  })
+})

--- a/src/main/native/process-utils-darwin.ts
+++ b/src/main/native/process-utils-darwin.ts
@@ -1,33 +1,83 @@
 import { execFile } from 'node:child_process'
+import path from 'node:path'
 import { promisify } from 'node:util'
 
 const execFileAsync = promisify(execFile)
 
-export async function getPidsByNamePosix(processName: string) {
-  const names = new Set([processName, processName.replace(/\.exe$/i, '')].filter(Boolean))
-  try {
-    const out = await execFileAsync('ps', ['-ax', '-o', 'pid=,comm='], { encoding: 'utf-8' })
-    const pids: number[] = []
-    for (const raw of out.stdout.split('\n')) {
-      const line = raw.trim()
-      if (!line) continue
-      const m = line.match(/^(\d+)\s+(.+)$/)
-      if (!m) continue
-      const pid = Number(m[1])
-      const comm = (m[2].split('/').pop() || m[2]).trim()
-      if (names.has(comm)) {
-        pids.push(pid)
-      }
+export interface PosixProcessInfo {
+  pid: number
+  executablePath: string
+  name: string
+}
+
+export function parsePosixProcessList(stdout: string): PosixProcessInfo[] {
+  const processes: PosixProcessInfo[] = []
+
+  for (const rawLine of stdout.split(/\r?\n/)) {
+    const match = rawLine.match(/^\s*(\d+)\s+(.+?)\s*$/)
+    if (!match) {
+      continue
     }
-    return Array.from(new Set(pids))
+
+    const pid = Number(match[1])
+    if (!Number.isSafeInteger(pid) || pid <= 0) {
+      continue
+    }
+
+    const executablePath = match[2]
+    processes.push({
+      pid,
+      executablePath,
+      name: path.basename(executablePath)
+    })
+  }
+
+  return processes
+}
+
+function normalizeProcessName(processName: string) {
+  return processName.replace(/\.exe$/i, '').toLowerCase()
+}
+
+export function findPidsByNamePosix(processes: readonly PosixProcessInfo[], processName: string) {
+  const normalizedName = normalizeProcessName(path.basename(processName))
+
+  return Array.from(
+    new Set(
+      processes
+        .filter((processInfo) => normalizeProcessName(processInfo.name) === normalizedName)
+        .map((processInfo) => processInfo.pid)
+    )
+  )
+}
+
+export async function listProcessesPosix() {
+  const { stdout } = await execFileAsync('ps', ['-ax', '-o', 'pid=,comm='], {
+    encoding: 'utf-8',
+    maxBuffer: 4 * 1024 * 1024
+  })
+
+  return parsePosixProcessList(stdout)
+}
+
+export async function getPidsByNamePosix(processName: string) {
+  try {
+    return findPidsByNamePosix(await listProcessesPosix(), processName)
   } catch {
     return []
   }
 }
 
 export async function getCommandLinePosix(pid: number) {
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    throw new TypeError(`Invalid process id: ${pid}`)
+  }
+
   return (
-    await execFileAsync('ps', ['-p', String(pid), '-o', 'command=', '-ww'], { encoding: 'utf-8' })
+    await execFileAsync('ps', ['-p', String(pid), '-o', 'command=', '-ww'], {
+      encoding: 'utf-8',
+      maxBuffer: 1024 * 1024
+    })
   ).stdout.trim()
 }
 

--- a/src/main/native/types.ts
+++ b/src/main/native/types.ts
@@ -1,0 +1,10 @@
+export interface NativeInputKeyEvent {
+  _nameRaw: string
+  name: string
+  standardName: string
+  keyId: string
+  keyCode: number
+  isModifier: boolean
+  isCommonModifier: boolean
+  isDown: boolean
+}

--- a/src/main/shards/app-common/index.ts
+++ b/src/main/shards/app-common/index.ts
@@ -14,6 +14,7 @@ import { SetterSettingService } from '../setting-factory/setter-setting-service'
 import { APP_COMMON_MAIN_NAMESPACE, type AppCommonMainContext } from './context'
 import { AppCommonDiagnosticsController } from './diagnostics-controller'
 import { AppCommonIpcHandlers } from './ipc-handlers'
+import { canRelaunchAsAdministrator } from './platform'
 import { RendererLinkProtocol } from './renderer-link-protocol'
 import { AppCommonSettings, AppCommonState } from './state'
 import { AppCommonThemeController } from './theme-controller'
@@ -132,6 +133,11 @@ export class AppCommonMain implements IAkariShardInitDispose {
   }
 
   async relaunchAsAdministrator() {
+    if (!canRelaunchAsAdministrator()) {
+      this._logger.warn('Administrator relaunch is unavailable on this platform', process.platform)
+      return { result: 'unsupported' as const, platform: process.platform }
+    }
+
     const appPath = process.execPath
 
     await execAsync(`"${elevateExecutablePath}" "${appPath}"`, {
@@ -139,6 +145,7 @@ export class AppCommonMain implements IAkariShardInitDispose {
     })
 
     app.exit()
+    return { result: 'relaunching' as const }
   }
 
   async getRuntimeInfo() {

--- a/src/main/shards/app-common/platform.test.ts
+++ b/src/main/shards/app-common/platform.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+import { canRelaunchAsAdministrator } from './platform'
+
+describe('app-common platform guards', () => {
+  it('only offers the Windows administrator relaunch flow on Windows', () => {
+    expect(canRelaunchAsAdministrator('win32')).toBe(true)
+    expect(canRelaunchAsAdministrator('darwin')).toBe(false)
+    expect(canRelaunchAsAdministrator('linux')).toBe(false)
+  })
+})

--- a/src/main/shards/app-common/platform.ts
+++ b/src/main/shards/app-common/platform.ts
@@ -1,0 +1,3 @@
+export function canRelaunchAsAdministrator(platform: NodeJS.Platform = process.platform) {
+  return platform === 'win32'
+}

--- a/src/main/shards/client-installation/client-launcher.test.ts
+++ b/src/main/shards/client-installation/client-launcher.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'vitest'
+
+import { buildMacClientLaunchCommand } from './client-launcher'
+
+describe('macOS Riot Client launcher command', () => {
+  const riotArguments = ['--launch-product=league_of_legends', '--launch-patchline=live']
+
+  test('opens an application bundle without shell interpolation and forwards arguments', () => {
+    expect(buildMacClientLaunchCommand('/Applications/Riot Client.app', riotArguments)).toEqual({
+      executablePath: 'open',
+      args: [
+        '-a',
+        '/Applications/Riot Client.app',
+        '--args',
+        '--launch-product=league_of_legends',
+        '--launch-patchline=live'
+      ]
+    })
+  })
+
+  test('executes a nested binary directly without adding shell quotes', () => {
+    expect(
+      buildMacClientLaunchCommand(
+        '/Users/Shared/Riot Games/Riot Client.app/Contents/MacOS/RiotClientServices',
+        riotArguments
+      )
+    ).toEqual({
+      executablePath: '/Users/Shared/Riot Games/Riot Client.app/Contents/MacOS/RiotClientServices',
+      args: riotArguments
+    })
+  })
+})

--- a/src/main/shards/client-installation/client-launcher.ts
+++ b/src/main/shards/client-installation/client-launcher.ts
@@ -1,10 +1,27 @@
 import cp from 'node:child_process'
-import util from 'node:util'
+import fs from 'node:fs'
 
 import type { ClientInstallationMainContext } from './context'
-import { shouldAllowWindowsOnlyLaunch } from './platform'
+import { shouldAllowDefaultRiotClientLaunch, shouldAllowWindowsOnlyLaunch } from './platform'
 
-const execFileAsync = util.promisify(cp.execFile)
+export interface MacClientLaunchCommand {
+  args: string[]
+  executablePath: string
+}
+
+export function buildMacClientLaunchCommand(
+  launchPath: string,
+  args: readonly string[]
+): MacClientLaunchCommand {
+  if (launchPath.toLowerCase().endsWith('.app')) {
+    return {
+      executablePath: 'open',
+      args: ['-a', launchPath, '--args', ...args]
+    }
+  }
+
+  return { executablePath: launchPath, args: [...args] }
+}
 
 export class ClientInstallationLauncher {
   constructor(private readonly _context: ClientInstallationMainContext) {}
@@ -58,6 +75,13 @@ export class ClientInstallationLauncher {
   }
 
   async launchDefaultRiotClient() {
+    if (!shouldAllowDefaultRiotClientLaunch()) {
+      this._context.logger.info('Skip Riot Client launch on unsupported platform', {
+        platform: process.platform
+      })
+      return
+    }
+
     const executablePath = this._context.state.officialRiotClientExecutablePath
 
     if (!executablePath) {
@@ -70,12 +94,29 @@ export class ClientInstallationLauncher {
       return this._spawnDetachedShell(executablePath, 'Riot client', args)
     }
 
-    if (process.platform === 'darwin' && executablePath.endsWith('.app')) {
-      await execFileAsync('open', ['-a', executablePath, '--args', ...args])
-      return
-    }
+    await fs.promises.access(executablePath)
+    const command = buildMacClientLaunchCommand(executablePath, args)
 
-    await execFileAsync(executablePath, args)
+    return this._spawnDetached(command.executablePath, command.args, 'Riot client')
+  }
+
+  private _spawnDetached(executablePath: string, args: string[], label: string) {
+    return new Promise<void>((resolve, reject) => {
+      const child = cp.spawn(executablePath, args, {
+        detached: true,
+        stdio: 'ignore',
+        shell: false
+      })
+
+      child.once('error', (error) => {
+        this._context.logger.warn(`Failed to launch ${label}`, executablePath, error)
+        reject(error)
+      })
+      child.once('spawn', () => {
+        child.unref()
+        resolve()
+      })
+    })
   }
 
   private _spawnDetachedShell(executablePath: string, label: string, args: string[] = []) {

--- a/src/main/shards/client-installation/installation-detector.ts
+++ b/src/main/shards/client-installation/installation-detector.ts
@@ -12,6 +12,7 @@ import {
   TENCENT_REG_INSTALL_VALUE,
   WEGAME_DEFAULTICON_PATH
 } from './context'
+import { MacInstallationLoader } from './macos-installation-loader'
 import { shouldScanMacInstallations, shouldScanTencentInstallations } from './platform'
 
 const execAsync = util.promisify(cp.exec)
@@ -25,11 +26,13 @@ if (regedit) {
 }
 
 export class ClientInstallationDetector {
+  private readonly _macInstallationLoader = new MacInstallationLoader()
+
   constructor(private readonly _context: ClientInstallationMainContext) {}
 
   async runPlatformDetection() {
     if (shouldScanMacInstallations()) {
-      await this.updateMacInstallationsByFile()
+      await this.updateMacInstallations()
       return
     }
 
@@ -287,48 +290,27 @@ export class ClientInstallationDetector {
     }
   }
 
-  async updateMacInstallationsByFile() {
+  async updateMacInstallations() {
     if (!shouldScanMacInstallations()) {
       return
     }
 
     const { state, logger } = this._context
 
-    const riotClientCandidates = [
-      '/Applications/Riot Client.app',
-      '/Users/Shared/Riot Games/Riot Client/Riot Client.app',
-      '/Applications/Riot Client.app/Contents/MacOS/Riot Client',
-      '/Users/Shared/Riot Games/Riot Client/Riot Client.app/Contents/MacOS/Riot Client'
-    ]
+    const installations = await this._macInstallationLoader.load()
 
-    for (const p of riotClientCandidates) {
-      try {
-        await fs.promises.access(p)
-        state.setOfficialRiotClientExecutablePath(p)
-        logger.info('Detected RiotClient installation on macOS', p)
-        break
-      } catch {}
+    if (installations.riotClientLaunchPath) {
+      state.setOfficialRiotClientExecutablePath(installations.riotClientLaunchPath)
+      logger.info('Detected RiotClient installation on macOS', installations.riotClientLaunchPath)
     }
 
-    const leagueCandidates = [
-      '/Applications/League of Legends.app/Contents/LoL/LeagueClient.app/Contents/MacOS/LeagueClient',
-      '/Applications/League of Legends.app/Contents/MacOS/LeagueofLegends',
-      '/Users/Shared/Riot Games/League of Legends.app/Contents/LoL/LeagueClient.app/Contents/MacOS/LeagueClient',
-      '/Users/Shared/Riot Games/League of Legends.app/Contents/MacOS/LeagueofLegends'
-    ]
-
-    const detectedLeagueClients: string[] = []
-    for (const p of leagueCandidates) {
-      try {
-        await fs.promises.access(p)
-        detectedLeagueClients.push(p)
-      } catch {}
+    if (installations.leagueClientExecutablePaths.length) {
+      logger.info(
+        'Detected LeagueClient installations on macOS',
+        installations.leagueClientExecutablePaths
+      )
     }
 
-    if (detectedLeagueClients.length) {
-      logger.info('Detected LeagueClient installations on macOS', detectedLeagueClients)
-    }
-
-    state.setLeagueClientExecutablePaths(detectedLeagueClients)
+    state.setLeagueClientExecutablePaths(installations.leagueClientExecutablePaths)
   }
 }

--- a/src/main/shards/client-installation/jump-list-controller.test.ts
+++ b/src/main/shards/client-installation/jump-list-controller.test.ts
@@ -1,0 +1,86 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { ClientInstallationJumpListController } from './jump-list-controller'
+
+const electronMocks = vi.hoisted(() => ({
+  setJumpList: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    setJumpList: electronMocks.setJumpList
+  }
+}))
+
+vi.mock('@main/i18n', () => ({
+  i18next: {
+    getFixedT: () => (key: string) => key
+  }
+}))
+
+vi.mock('@main/utils/deep-link', () => ({
+  DEEP_LINK_PROTOCOL: 'league-akari'
+}))
+
+function createContext(startupDeepLink: string | null = null) {
+  const events = new EventEmitter()
+  const state = {
+    tclsExecutablePath: null,
+    weGameLauncherExecutablePath: null,
+    officialRiotClientExecutablePath: '/Applications/Riot Client.app'
+  }
+
+  return {
+    events,
+    context: {
+      appCommon: { settings: { locale: 'en' } },
+      logger: { info: vi.fn(), warn: vi.fn() },
+      mobxUtils: {
+        reaction: vi.fn((expression: () => unknown, effect: () => void) => {
+          expression()
+          effect()
+        })
+      },
+      shared: { global: { events, startupDeepLink } },
+      state
+    }
+  }
+}
+
+describe('client installation deep links on macOS', () => {
+  beforeEach(() => {
+    electronMocks.setJumpList.mockReset()
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('handles a startup Riot launch without creating a Windows Jump List', () => {
+    const { context } = createContext(
+      'league-akari://shards/client-installation-main/launch-riot-client-lol'
+    )
+    const launcher = { launchDefaultRiotClient: vi.fn() }
+
+    new ClientInstallationJumpListController(context as any, launcher as any).register()
+
+    expect(launcher.launchDefaultRiotClient).toHaveBeenCalledOnce()
+    expect(electronMocks.setJumpList).not.toHaveBeenCalled()
+  })
+
+  test('handles Riot launch links delivered through the macOS open-url path', () => {
+    const { context, events } = createContext()
+    const launcher = { launchDefaultRiotClient: vi.fn() }
+
+    new ClientInstallationJumpListController(context as any, launcher as any).register()
+    events.emit(
+      'second-instance-deep-link',
+      'league-akari://shards/client-installation-main/launch-riot-client-lol'
+    )
+
+    expect(launcher.launchDefaultRiotClient).toHaveBeenCalledOnce()
+    expect(electronMocks.setJumpList).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/shards/client-installation/jump-list-controller.ts
+++ b/src/main/shards/client-installation/jump-list-controller.ts
@@ -20,7 +20,6 @@ export class ClientInstallationJumpListController {
       this._context.logger.info('Skip client installation Jump List on unsupported platform', {
         platform: process.platform
       })
-      return
     }
 
     this._context.mobxUtils.reaction(
@@ -31,7 +30,9 @@ export class ClientInstallationJumpListController {
         this._context.state.officialRiotClientExecutablePath
       ],
       () => {
-        this._buildJumpList()
+        if (shouldRegisterJumpList()) {
+          this._buildJumpList()
+        }
 
         if (this._context.shared.global.startupDeepLink && !this._startupLaunch) {
           this._handleDeepLink(this._context.shared.global.startupDeepLink, false)

--- a/src/main/shards/client-installation/macos-installation-loader.test.ts
+++ b/src/main/shards/client-installation/macos-installation-loader.test.ts
@@ -1,0 +1,196 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, test } from 'vitest'
+
+import {
+  MacInstallationLoader,
+  buildMacBundleExecutablePath,
+  getMacApplicationBundlePath,
+  parseRiotClientInstallMetadata
+} from './macos-installation-loader'
+
+const temporaryDirectories: string[] = []
+
+async function makeTemporaryDirectory() {
+  const directory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'league-akari-macos-'))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+async function createApplicationBundle(bundlePath: string, bundleExecutable: string) {
+  const executablePath = buildMacBundleExecutablePath(bundlePath, bundleExecutable)
+  if (!executablePath) {
+    throw new Error('Invalid test bundle executable')
+  }
+
+  await fs.promises.mkdir(path.join(bundlePath, 'Contents'), { recursive: true })
+  await fs.promises.mkdir(path.dirname(executablePath), { recursive: true })
+  await fs.promises.writeFile(
+    path.join(bundlePath, 'Contents', 'Info.plist'),
+    `<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+  <key>CFBundleExecutable</key><string>${bundleExecutable}</string>
+</dict></plist>`
+  )
+  await fs.promises.writeFile(executablePath, '#!/bin/sh\n')
+  await fs.promises.chmod(executablePath, 0o755)
+
+  return executablePath
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => fs.promises.rm(directory, { force: true, recursive: true }))
+  )
+})
+
+describe('macOS client installation paths', () => {
+  test('distinguishes outer and inner application bundles', () => {
+    const executablePath = path.join(
+      path.sep,
+      'Applications',
+      'League of Legends.app',
+      'Contents',
+      'LoL',
+      'League of Legends.app',
+      'Contents',
+      'MacOS',
+      'LeagueClientUx'
+    )
+
+    expect(getMacApplicationBundlePath(executablePath, 'outermost')).toBe(
+      path.join(path.sep, 'Applications', 'League of Legends.app')
+    )
+    expect(getMacApplicationBundlePath(executablePath, 'innermost')).toBe(
+      path.join(
+        path.sep,
+        'Applications',
+        'League of Legends.app',
+        'Contents',
+        'LoL',
+        'League of Legends.app'
+      )
+    )
+  })
+
+  test('resolves conventional and nested CFBundleExecutable values safely', () => {
+    const bundlePath = path.join(path.sep, 'Applications', 'League of Legends.app')
+
+    expect(buildMacBundleExecutablePath(bundlePath, 'LeagueClient')).toBe(
+      path.join(bundlePath, 'Contents', 'MacOS', 'LeagueClient')
+    )
+    expect(
+      buildMacBundleExecutablePath(bundlePath, 'LoL/LeagueClient.app/Contents/MacOS/LeagueClient')
+    ).toBe(
+      path.join(
+        bundlePath,
+        'Contents',
+        'LoL',
+        'LeagueClient.app',
+        'Contents',
+        'MacOS',
+        'LeagueClient'
+      )
+    )
+    expect(buildMacBundleExecutablePath(bundlePath, '../../outside')).toBeNull()
+  })
+
+  test('extracts custom League and Riot paths from Riot installation metadata', () => {
+    expect(
+      parseRiotClientInstallMetadata(
+        JSON.stringify({
+          associated_client: {
+            '/Volumes/Games/League of Legends.app/Contents/LoL/LeagueClient.app':
+              '/Volumes/Games/Riot Client.app/Contents/MacOS/RiotClientServices'
+          },
+          rc_default: '/Volumes/Games/Riot Client.app/Contents/MacOS/RiotClientServices',
+          patchlines: {
+            KeystoneFoundationLiveMac:
+              '/Volumes/Games/Riot Client.app/Contents/MacOS/RiotClientServices'
+          }
+        })
+      )
+    ).toEqual({
+      leagueClientCandidates: [
+        path.normalize('/Volumes/Games/League of Legends.app/Contents/LoL/LeagueClient.app')
+      ],
+      riotClientCandidates: [
+        path.normalize('/Volumes/Games/Riot Client.app/Contents/MacOS/RiotClientServices')
+      ]
+    })
+  })
+
+  test('prioritizes validated running clients and retains metadata fallbacks', async () => {
+    const temporaryDirectory = await makeTemporaryDirectory()
+
+    const runningLeagueBundle = path.join(temporaryDirectory, 'Running League.app')
+    const runningLeagueExecutable = await createApplicationBundle(
+      runningLeagueBundle,
+      'LoL/LeagueClient.app/Contents/MacOS/LeagueClient'
+    )
+    await createApplicationBundle(
+      path.join(runningLeagueBundle, 'Contents', 'LoL', 'LeagueClient.app'),
+      'LeagueClient'
+    )
+    const runningUxBundle = path.join(
+      runningLeagueBundle,
+      'Contents',
+      'LoL',
+      'League of Legends.app'
+    )
+    const runningUxExecutable = await createApplicationBundle(runningUxBundle, 'LeagueClientUx')
+
+    const runningRiotBundle = path.join(temporaryDirectory, 'Running Riot Client.app')
+    const runningRiotExecutable = await createApplicationBundle(
+      runningRiotBundle,
+      'RiotClientServices'
+    )
+
+    const fallbackLeagueBundle = path.join(temporaryDirectory, 'Fallback LeagueClient.app')
+    const fallbackLeagueExecutable = await createApplicationBundle(
+      fallbackLeagueBundle,
+      'LeagueClient'
+    )
+    const fallbackRiotBundle = path.join(temporaryDirectory, 'Fallback Riot Client.app')
+    const fallbackRiotExecutable = await createApplicationBundle(
+      fallbackRiotBundle,
+      'RiotClientServices'
+    )
+    const metadataPath = path.join(temporaryDirectory, 'RiotClientInstalls.json')
+    await fs.promises.writeFile(
+      metadataPath,
+      JSON.stringify({
+        associated_client: {
+          [fallbackLeagueBundle]: fallbackRiotExecutable
+        },
+        rc_default: fallbackRiotExecutable
+      })
+    )
+
+    const loader = new MacInstallationLoader({
+      listProcesses: async () => [
+        {
+          pid: 11,
+          executablePath: runningRiotExecutable,
+          name: 'RiotClientServices'
+        },
+        { pid: 12, executablePath: runningUxExecutable, name: 'LeagueClientUx' }
+      ],
+      getCommandLine: async () =>
+        `${runningUxExecutable} ` +
+        `--install-directory=${path.join(runningLeagueBundle, 'Contents', 'LoL')} ` +
+        '--remoting-auth-token=synthetic-lcu-secret --riotclient-auth-token=synthetic-riot-secret',
+      riotClientInstallMetadataPaths: [metadataPath],
+      searchRoots: []
+    })
+
+    const installations = await loader.load()
+
+    expect(installations.riotClientLaunchPath).toBe(runningRiotBundle)
+    expect(installations.leagueClientExecutablePaths[0]).toBe(runningLeagueExecutable)
+    expect(installations.leagueClientExecutablePaths).toContain(fallbackLeagueExecutable)
+  })
+})

--- a/src/main/shards/client-installation/macos-installation-loader.ts
+++ b/src/main/shards/client-installation/macos-installation-loader.ts
@@ -1,0 +1,412 @@
+import { getProcessCommandLineOption } from '@main/native/process-command-line'
+import {
+  type PosixProcessInfo,
+  getCommandLinePosix,
+  listProcessesPosix
+} from '@main/native/process-utils-darwin'
+import { execFile } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+
+const RIOT_CLIENT_PROCESS_NAMES = new Set(['riot client', 'riotclientservices'])
+const LEAGUE_CLIENT_PROCESS_NAMES = new Set(['leagueclient', 'leagueclientux', 'leagueoflegends'])
+
+const RIOT_CLIENT_EXECUTABLE_NAMES = new Set(['riot client', 'riotclientservices'])
+
+export interface MacClientInstallationPaths {
+  leagueClientExecutablePaths: string[]
+  riotClientLaunchPath: string | null
+}
+
+export interface RiotClientInstallMetadataCandidates {
+  leagueClientCandidates: string[]
+  riotClientCandidates: string[]
+}
+
+export interface MacInstallationLoaderOptions {
+  getCommandLine?: (pid: number) => Promise<string>
+  listProcesses?: () => Promise<PosixProcessInfo[]>
+  riotClientInstallMetadataPaths?: string[]
+  searchRoots?: string[]
+}
+
+function normalizeExecutableName(name: string) {
+  return name.replace(/\.exe$/i, '').toLowerCase()
+}
+
+function uniquePaths(paths: readonly string[]) {
+  return Array.from(new Set(paths.map((candidate) => path.normalize(candidate))))
+}
+
+function decodeXmlText(value: string) {
+  return value
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&')
+}
+
+export function getMacApplicationBundlePath(
+  candidatePath: string,
+  preference: 'innermost' | 'outermost' = 'outermost'
+) {
+  const bundles: string[] = []
+  let currentPath = candidatePath.toLowerCase().endsWith('.app')
+    ? path.normalize(candidatePath)
+    : path.dirname(path.normalize(candidatePath))
+
+  while (true) {
+    if (path.basename(currentPath).toLowerCase().endsWith('.app')) {
+      bundles.push(currentPath)
+    }
+
+    const parentPath = path.dirname(currentPath)
+    if (parentPath === currentPath) {
+      break
+    }
+    currentPath = parentPath
+  }
+
+  if (!bundles.length) {
+    return null
+  }
+
+  return preference === 'innermost' ? bundles[0] : bundles[bundles.length - 1]
+}
+
+export function buildMacBundleExecutablePath(bundlePath: string, bundleExecutable: string) {
+  const contentsPath = path.resolve(bundlePath, 'Contents')
+  const executablePath =
+    bundleExecutable.includes('/') || bundleExecutable.includes('\\')
+      ? path.resolve(contentsPath, bundleExecutable)
+      : path.resolve(contentsPath, 'MacOS', bundleExecutable)
+  const relativePath = path.relative(contentsPath, executablePath)
+
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    return null
+  }
+
+  return executablePath
+}
+
+export function inferLeagueClientCandidatesFromPath(candidatePath: string) {
+  const candidates = [candidatePath]
+  let currentPath = candidatePath.toLowerCase().endsWith('.app')
+    ? path.normalize(candidatePath)
+    : path.dirname(path.normalize(candidatePath))
+
+  while (true) {
+    if (path.basename(currentPath).toLowerCase() === 'lol') {
+      candidates.push(path.join(currentPath, 'LeagueClient.app'))
+    }
+
+    if (path.basename(currentPath).toLowerCase().endsWith('.app')) {
+      candidates.push(path.join(path.dirname(currentPath), 'LeagueClient.app'))
+    }
+
+    const parentPath = path.dirname(currentPath)
+    if (parentPath === currentPath) {
+      break
+    }
+    currentPath = parentPath
+  }
+
+  candidates.push(
+    path.join(candidatePath, 'LeagueClient.app'),
+    path.join(candidatePath, 'Contents', 'LoL', 'LeagueClient.app')
+  )
+
+  return uniquePaths(candidates)
+}
+
+export function parseRiotClientInstallMetadata(
+  serializedMetadata: string
+): RiotClientInstallMetadataCandidates {
+  const metadata: unknown = JSON.parse(serializedMetadata)
+  if (!metadata || typeof metadata !== 'object') {
+    return { leagueClientCandidates: [], riotClientCandidates: [] }
+  }
+
+  const record = metadata as Record<string, unknown>
+  const associatedClients =
+    record.associated_client && typeof record.associated_client === 'object'
+      ? (record.associated_client as Record<string, unknown>)
+      : {}
+  const leagueClientCandidates = Object.keys(associatedClients)
+  const riotClientCandidates = [
+    ...Object.values(associatedClients),
+    record.rc_default,
+    record.rc_live,
+    ...(record.patchlines && typeof record.patchlines === 'object'
+      ? Object.values(record.patchlines as Record<string, unknown>)
+      : [])
+  ].filter((candidate): candidate is string => typeof candidate === 'string')
+
+  return {
+    leagueClientCandidates: uniquePaths(leagueClientCandidates),
+    riotClientCandidates: uniquePaths(riotClientCandidates)
+  }
+}
+
+export class MacInstallationLoader {
+  private readonly _getCommandLine: (pid: number) => Promise<string>
+  private readonly _listProcesses: () => Promise<PosixProcessInfo[]>
+  private readonly _riotClientInstallMetadataPaths: string[]
+  private readonly _searchRoots: string[]
+
+  constructor(options: MacInstallationLoaderOptions = {}) {
+    this._getCommandLine = options.getCommandLine ?? getCommandLinePosix
+    this._listProcesses = options.listProcesses ?? listProcessesPosix
+    this._searchRoots =
+      options.searchRoots ??
+      uniquePaths([
+        '/Applications',
+        path.join(os.homedir(), 'Applications'),
+        '/Users/Shared/Riot Games'
+      ])
+    this._riotClientInstallMetadataPaths =
+      options.riotClientInstallMetadataPaths ??
+      uniquePaths([
+        '/Users/Shared/Riot Games/RiotClientInstalls.json',
+        path.join(
+          os.homedir(),
+          'Library',
+          'Application Support',
+          'Riot Games',
+          'RiotClientInstalls.json'
+        )
+      ])
+  }
+
+  async load(): Promise<MacClientInstallationPaths> {
+    const runningInstallations = await this._loadRunningProcessInstallations()
+    const filesystemInstallations = await this._loadFilesystemInstallations()
+
+    return {
+      riotClientLaunchPath:
+        runningInstallations.riotClientLaunchPath ?? filesystemInstallations.riotClientLaunchPath,
+      leagueClientExecutablePaths: uniquePaths([
+        ...runningInstallations.leagueClientExecutablePaths,
+        ...filesystemInstallations.leagueClientExecutablePaths
+      ])
+    }
+  }
+
+  private async _loadRunningProcessInstallations(): Promise<MacClientInstallationPaths> {
+    let processes: PosixProcessInfo[]
+    try {
+      processes = await this._listProcesses()
+    } catch {
+      return { leagueClientExecutablePaths: [], riotClientLaunchPath: null }
+    }
+
+    const riotProcesses = processes
+      .filter((processInfo) =>
+        RIOT_CLIENT_PROCESS_NAMES.has(normalizeExecutableName(processInfo.name))
+      )
+      .sort((left, right) => {
+        const leftRank = normalizeExecutableName(left.name) === 'riotclientservices' ? 0 : 1
+        const rightRank = normalizeExecutableName(right.name) === 'riotclientservices' ? 0 : 1
+        return leftRank - rightRank
+      })
+    const leagueProcesses = processes
+      .filter((processInfo) =>
+        LEAGUE_CLIENT_PROCESS_NAMES.has(normalizeExecutableName(processInfo.name))
+      )
+      .sort((left, right) => {
+        const ranks: Record<string, number> = {
+          leagueclient: 0,
+          leagueclientux: 1,
+          leagueoflegends: 2
+        }
+        return (
+          ranks[normalizeExecutableName(left.name)] - ranks[normalizeExecutableName(right.name)]
+        )
+      })
+
+    let riotClientLaunchPath: string | null = null
+    for (const processInfo of riotProcesses) {
+      riotClientLaunchPath = await this._resolveRiotClientLaunchPath(processInfo.executablePath)
+      if (riotClientLaunchPath) {
+        break
+      }
+    }
+
+    const leagueCandidates: string[] = []
+    for (const processInfo of leagueProcesses) {
+      leagueCandidates.push(...inferLeagueClientCandidatesFromPath(processInfo.executablePath))
+
+      try {
+        const commandLine = await this._getCommandLine(processInfo.pid)
+        const installationDirectory = getProcessCommandLineOption(commandLine, [
+          'install-directory',
+          'install_directory',
+          'product-install-path',
+          'product_install_full_path'
+        ])
+        const applicationDirectory = getProcessCommandLineOption(commandLine, [
+          'app-directory',
+          'app_directory',
+          'app-root'
+        ])
+
+        if (installationDirectory) {
+          leagueCandidates.push(...inferLeagueClientCandidatesFromPath(installationDirectory))
+        }
+        if (applicationDirectory) {
+          leagueCandidates.push(...inferLeagueClientCandidatesFromPath(applicationDirectory))
+        }
+      } catch {
+        // A process can exit between the process-list and command-line reads.
+      }
+    }
+
+    return {
+      riotClientLaunchPath,
+      leagueClientExecutablePaths: await this._resolveLeagueClientExecutables(leagueCandidates)
+    }
+  }
+
+  private async _loadFilesystemInstallations(): Promise<MacClientInstallationPaths> {
+    const riotCandidates: string[] = []
+    const leagueCandidates: string[] = []
+
+    for (const metadataPath of this._riotClientInstallMetadataPaths) {
+      try {
+        const metadata = parseRiotClientInstallMetadata(
+          await fs.promises.readFile(metadataPath, 'utf-8')
+        )
+        riotCandidates.push(...metadata.riotClientCandidates)
+        leagueCandidates.push(...metadata.leagueClientCandidates)
+      } catch {
+        // Missing or malformed metadata must not prevent the normal application-root scan.
+      }
+    }
+
+    for (const searchRoot of this._searchRoots) {
+      riotCandidates.push(
+        path.join(searchRoot, 'Riot Client.app'),
+        path.join(searchRoot, 'Riot Games', 'Riot Client.app')
+      )
+      leagueCandidates.push(
+        path.join(searchRoot, 'League of Legends.app'),
+        path.join(searchRoot, 'Riot Games', 'League of Legends.app')
+      )
+    }
+
+    let riotClientLaunchPath: string | null = null
+    for (const candidate of uniquePaths(riotCandidates)) {
+      riotClientLaunchPath = await this._resolveRiotClientLaunchPath(candidate)
+      if (riotClientLaunchPath) {
+        break
+      }
+    }
+
+    return {
+      riotClientLaunchPath,
+      leagueClientExecutablePaths: await this._resolveLeagueClientExecutables(leagueCandidates)
+    }
+  }
+
+  private async _resolveRiotClientLaunchPath(candidatePath: string) {
+    const bundlePath = getMacApplicationBundlePath(candidatePath)
+    if (bundlePath) {
+      const executablePath = await this._resolveBundleExecutable(bundlePath)
+      if (
+        executablePath &&
+        RIOT_CLIENT_EXECUTABLE_NAMES.has(normalizeExecutableName(path.basename(executablePath)))
+      ) {
+        return bundlePath
+      }
+    }
+
+    if (
+      RIOT_CLIENT_EXECUTABLE_NAMES.has(normalizeExecutableName(path.basename(candidatePath))) &&
+      (await this._isExecutableFile(candidatePath))
+    ) {
+      return path.normalize(candidatePath)
+    }
+
+    return null
+  }
+
+  private async _resolveLeagueClientExecutables(candidates: readonly string[]) {
+    const executables: string[] = []
+
+    for (const candidate of uniquePaths(candidates)) {
+      for (const inferredCandidate of inferLeagueClientCandidatesFromPath(candidate)) {
+        let executablePath: string | null = null
+        if (inferredCandidate.toLowerCase().endsWith('.app')) {
+          executablePath = await this._resolveBundleExecutable(inferredCandidate)
+        } else if (await this._isExecutableFile(inferredCandidate)) {
+          executablePath = inferredCandidate
+        }
+
+        if (
+          executablePath &&
+          normalizeExecutableName(path.basename(executablePath)) === 'leagueclient'
+        ) {
+          executables.push(path.normalize(executablePath))
+          break
+        }
+      }
+    }
+
+    return uniquePaths(executables)
+  }
+
+  private async _resolveBundleExecutable(bundlePath: string) {
+    try {
+      if (!(await fs.promises.stat(bundlePath)).isDirectory()) {
+        return null
+      }
+
+      const infoPlistPath = path.join(bundlePath, 'Contents', 'Info.plist')
+      const plist = await fs.promises.readFile(infoPlistPath)
+      let bundleExecutable: string | null = null
+
+      if (!plist.subarray(0, 6).equals(Buffer.from('bplist'))) {
+        const match = plist
+          .toString('utf-8')
+          .match(/<key>\s*CFBundleExecutable\s*<\/key>\s*<string>([\s\S]*?)<\/string>/i)
+        bundleExecutable = match ? decodeXmlText(match[1].trim()) : null
+      } else if (process.platform === 'darwin') {
+        const { stdout } = await execFileAsync(
+          '/usr/bin/plutil',
+          ['-extract', 'CFBundleExecutable', 'raw', '-o', '-', infoPlistPath],
+          { encoding: 'utf-8' }
+        )
+        bundleExecutable = stdout.trim()
+      }
+
+      if (!bundleExecutable) {
+        return null
+      }
+
+      const executablePath = buildMacBundleExecutablePath(bundlePath, bundleExecutable)
+      return executablePath && (await this._isExecutableFile(executablePath))
+        ? path.normalize(executablePath)
+        : null
+    } catch {
+      return null
+    }
+  }
+
+  private async _isExecutableFile(candidatePath: string) {
+    try {
+      const stats = await fs.promises.stat(candidatePath)
+      if (!stats.isFile()) {
+        return false
+      }
+      await fs.promises.access(candidatePath, fs.constants.X_OK)
+      return true
+    } catch {
+      return false
+    }
+  }
+}

--- a/src/main/shards/client-installation/platform.test.ts
+++ b/src/main/shards/client-installation/platform.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 
 import {
+  shouldAllowDefaultRiotClientLaunch,
   shouldAllowWindowsOnlyLaunch,
   shouldRegisterJumpList,
   shouldScanMacInstallations,
@@ -25,5 +26,11 @@ describe('client-installation platform guards', () => {
     expect(shouldScanMacInstallations('darwin')).toBe(true)
     expect(shouldScanMacInstallations('win32')).toBe(false)
     expect(shouldScanMacInstallations('linux')).toBe(false)
+  })
+
+  test('allows the default Riot Client launcher on Windows and macOS', () => {
+    expect(shouldAllowDefaultRiotClientLaunch('win32')).toBe(true)
+    expect(shouldAllowDefaultRiotClientLaunch('darwin')).toBe(true)
+    expect(shouldAllowDefaultRiotClientLaunch('linux')).toBe(false)
   })
 })

--- a/src/main/shards/client-installation/platform.ts
+++ b/src/main/shards/client-installation/platform.ts
@@ -17,3 +17,7 @@ export function shouldWatchLiveStreamingClients(platform: NodeJS.Platform = proc
 export function shouldAllowWindowsOnlyLaunch(platform: NodeJS.Platform = process.platform) {
   return platform === 'win32'
 }
+
+export function shouldAllowDefaultRiotClientLaunch(platform: NodeJS.Platform = process.platform) {
+  return platform === 'win32' || platform === 'darwin'
+}

--- a/src/main/shards/game-client/context.ts
+++ b/src/main/shards/game-client/context.ts
@@ -6,10 +6,11 @@ import type { AkariLogger } from '../logger-factory'
 import type { MobxUtilsMain } from '../mobx-utils'
 import type { SetterSettingService } from '../setting-factory/setter-setting-service'
 import type { GameClientMain } from './index'
+import { getGameClientProcessName } from './platform'
 import type { GameClientSettings } from './state'
 
 export const GAME_CLIENT_MAIN_NAMESPACE = 'game-client-main'
-export const GAME_CLIENT_PROCESS_NAME = 'League of Legends.exe'
+export const GAME_CLIENT_PROCESS_NAME = getGameClientProcessName()
 export const GAME_CLIENT_BASE_URL = 'https://127.0.0.1:2999'
 export const TERMINATE_GAME_CLIENT_SHORTCUT_TARGET_ID = `${GAME_CLIENT_MAIN_NAMESPACE}/terminate-game-client`
 

--- a/src/main/shards/game-client/index.test.ts
+++ b/src/main/shards/game-client/index.test.ts
@@ -1,0 +1,117 @@
+import 'reflect-metadata'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { GameClientMain } from './index'
+
+const nativeMock = vi.hoisted(() => ({
+  foregroundAvailable: false,
+  getPidsByName: vi.fn<() => Promise<number[]>>(),
+  isProcessForeground: vi.fn<(pid: number) => boolean>(),
+  isProcessRunning: vi.fn<(pid: number) => boolean>(),
+  terminateProcess: vi.fn<(pid: number) => boolean>()
+}))
+
+vi.mock('@main/native', () => ({
+  NATIVE_SUPPORT: {
+    isProcessForeground: {
+      get available() {
+        return nativeMock.foregroundAvailable
+      }
+    }
+  },
+  getPidsByName: nativeMock.getPidsByName,
+  isProcessForeground: nativeMock.isProcessForeground,
+  isProcessRunning: nativeMock.isProcessRunning,
+  terminateProcess: nativeMock.terminateProcess
+}))
+
+vi.mock('../client-installation', () => ({ ClientInstallationMain: class {} }))
+vi.mock('../ipc', () => ({ AkariIpcMain: class {} }))
+vi.mock('../keyboard-shortcuts', () => ({ KeyboardShortcutsMain: class {} }))
+vi.mock('../league-client', () => ({ LeagueClientMain: class {} }))
+vi.mock('../logger-factory', () => ({
+  LoggerFactoryMain: class {},
+  AkariLogger: class {}
+}))
+vi.mock('../mobx-utils', () => ({ MobxUtilsMain: class {} }))
+vi.mock('../setting-factory', () => ({ SettingFactoryMain: class {} }))
+vi.mock('./ipc-handlers', () => ({
+  GameClientIpcHandlers: class {
+    register() {}
+  }
+}))
+vi.mock('./settings-file-controller', () => ({
+  GameClientSettingsFileController: class {}
+}))
+vi.mock('./shortcut-controller', () => ({
+  GameClientShortcutController: class {
+    watch() {}
+    applyTerminateShortcutSettingSideEffect() {}
+  }
+}))
+
+function createGameClient() {
+  return new GameClientMain(
+    { onCall: vi.fn() } as any,
+    {
+      create: () => ({
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn()
+      })
+    } as any,
+    {
+      register: () => ({
+        applyToState: vi.fn()
+      })
+    } as any,
+    {} as any,
+    {
+      register: vi.fn(),
+      unregisterByTargetId: vi.fn()
+    } as any,
+    { propSync: vi.fn() } as any,
+    {} as any
+  )
+}
+
+describe('GameClientMain native capability gating', () => {
+  beforeEach(() => {
+    nativeMock.foregroundAvailable = false
+    nativeMock.getPidsByName.mockReset()
+    nativeMock.isProcessForeground.mockReset()
+    nativeMock.isProcessRunning.mockReset()
+    nativeMock.terminateProcess.mockReset()
+  })
+
+  it('does not call the Win32 foreground API when that capability is unavailable', async () => {
+    await expect(GameClientMain.isGameClientForeground()).resolves.toBe(false)
+
+    expect(nativeMock.getPidsByName).not.toHaveBeenCalled()
+    expect(nativeMock.isProcessForeground).not.toHaveBeenCalled()
+  })
+
+  it('keeps cross-platform process termination without calling the unavailable foreground API', async () => {
+    nativeMock.getPidsByName.mockResolvedValue([101])
+    nativeMock.terminateProcess.mockReturnValue(true)
+
+    await createGameClient().terminateGameClient()
+
+    expect(nativeMock.isProcessForeground).not.toHaveBeenCalled()
+    expect(nativeMock.terminateProcess).toHaveBeenCalledWith(101)
+  })
+
+  it('preserves Windows foreground filtering when the capability is available', async () => {
+    nativeMock.foregroundAvailable = true
+    nativeMock.getPidsByName.mockResolvedValue([101, 202])
+    nativeMock.isProcessForeground.mockImplementation((pid) => pid === 202)
+    nativeMock.terminateProcess.mockReturnValue(true)
+
+    await createGameClient().terminateGameClient()
+
+    expect(nativeMock.terminateProcess).toHaveBeenCalledOnce()
+    expect(nativeMock.terminateProcess).toHaveBeenCalledWith(202)
+  })
+})

--- a/src/main/shards/game-client/index.ts
+++ b/src/main/shards/game-client/index.ts
@@ -49,6 +49,7 @@ export class GameClientMain implements IAkariShardInitDispose {
 
   private readonly _httpClient = axios.create({
     baseURL: GameClientMain.GAME_CLIENT_BASE_URL,
+    allowAbsoluteUrls: false,
     httpsAgent: new https.Agent({
       rejectUnauthorized: false,
       keepAlive: true,
@@ -124,7 +125,7 @@ export class GameClientMain implements IAkariShardInitDispose {
 
     pids.forEach((pid) => {
       this._logger.info('Process exists', pid)
-      if (NATIVE_SUPPORT.isProcessForeground && !isProcessForeground(pid)) {
+      if (NATIVE_SUPPORT.isProcessForeground.available && !isProcessForeground(pid)) {
         this._logger.info('Process is not in foreground', pid)
         return
       }
@@ -143,7 +144,7 @@ export class GameClientMain implements IAkariShardInitDispose {
   }
 
   static async isGameClientForeground() {
-    if (!NATIVE_SUPPORT.isProcessForeground) {
+    if (!NATIVE_SUPPORT.isProcessForeground.available) {
       return false
     }
 
@@ -153,7 +154,7 @@ export class GameClientMain implements IAkariShardInitDispose {
   }
 
   async isGameClientForegroundCached() {
-    if (!NATIVE_SUPPORT.isProcessForeground) {
+    if (!NATIVE_SUPPORT.isProcessForeground.available) {
       return false
     }
 

--- a/src/main/shards/game-client/platform.test.ts
+++ b/src/main/shards/game-client/platform.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { getGameClientProcessName } from './platform'
+
+describe('game-client process names', () => {
+  it('uses the actual macOS Mach-O process name', () => {
+    expect(getGameClientProcessName('darwin')).toBe('LeagueofLegends')
+  })
+
+  it('preserves the Win32 process name', () => {
+    expect(getGameClientProcessName('win32')).toBe('League of Legends.exe')
+  })
+})

--- a/src/main/shards/game-client/platform.ts
+++ b/src/main/shards/game-client/platform.ts
@@ -1,0 +1,6 @@
+const WINDOWS_GAME_CLIENT_PROCESS_NAME = 'League of Legends.exe'
+const DARWIN_GAME_CLIENT_PROCESS_NAME = 'LeagueofLegends'
+
+export function getGameClientProcessName(platform: NodeJS.Platform = process.platform) {
+  return platform === 'darwin' ? DARWIN_GAME_CLIENT_PROCESS_NAME : WINDOWS_GAME_CLIENT_PROCESS_NAME
+}

--- a/src/main/shards/game-client/shortcut-controller.test.ts
+++ b/src/main/shards/game-client/shortcut-controller.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { TERMINATE_GAME_CLIENT_SHORTCUT_TARGET_ID } from './context'
+import { GameClientShortcutController } from './shortcut-controller'
+
+const nativeSupportMock = vi.hoisted(() => ({
+  isProcessForeground: { available: true }
+}))
+
+vi.mock('@main/native', () => ({
+  NATIVE_SUPPORT: nativeSupportMock
+}))
+
+function createController() {
+  const keyboardShortcuts = {
+    register: vi.fn(),
+    unregisterByTargetId: vi.fn()
+  }
+  const context = {
+    gameClient: { terminateGameClient: vi.fn() },
+    keyboardShortcuts,
+    logger: { warn: vi.fn() },
+    settings: {
+      terminateGameClientWithShortcut: true,
+      terminateShortcut: 'Control+Q'
+    }
+  }
+
+  return {
+    context,
+    controller: new GameClientShortcutController(context as any),
+    keyboardShortcuts
+  }
+}
+
+describe('GameClientShortcutController capability gating', () => {
+  beforeEach(() => {
+    nativeSupportMock.isProcessForeground.available = true
+  })
+
+  it('registers the foreground-only termination shortcut when supported', () => {
+    const { controller, keyboardShortcuts } = createController()
+
+    controller.watch()
+
+    expect(keyboardShortcuts.register).toHaveBeenCalledWith(
+      TERMINATE_GAME_CLIENT_SHORTCUT_TARGET_ID,
+      'Control+Q',
+      'normal',
+      expect.any(Function)
+    )
+  })
+
+  it('removes persisted registrations when foreground detection is unavailable', () => {
+    nativeSupportMock.isProcessForeground.available = false
+    const { controller, keyboardShortcuts } = createController()
+
+    controller.watch()
+    controller.applyTerminateShortcutSettingSideEffect('Control+Q')
+
+    expect(keyboardShortcuts.register).not.toHaveBeenCalled()
+    expect(keyboardShortcuts.unregisterByTargetId).toHaveBeenCalledTimes(2)
+    expect(keyboardShortcuts.unregisterByTargetId).toHaveBeenCalledWith(
+      TERMINATE_GAME_CLIENT_SHORTCUT_TARGET_ID
+    )
+  })
+})

--- a/src/main/shards/game-client/shortcut-controller.ts
+++ b/src/main/shards/game-client/shortcut-controller.ts
@@ -1,3 +1,5 @@
+import { NATIVE_SUPPORT } from '@main/native'
+
 import { type GameClientMainContext, TERMINATE_GAME_CLIENT_SHORTCUT_TARGET_ID } from './context'
 
 export class GameClientShortcutController {
@@ -6,12 +8,22 @@ export class GameClientShortcutController {
   watch() {
     const { settings } = this.context
 
+    if (!NATIVE_SUPPORT.isProcessForeground.available) {
+      this.context.keyboardShortcuts.unregisterByTargetId(TERMINATE_GAME_CLIENT_SHORTCUT_TARGET_ID)
+      return
+    }
+
     if (settings.terminateShortcut) {
       this._registerTerminateShortcut(settings.terminateShortcut, 'initialize')
     }
   }
 
   applyTerminateShortcutSettingSideEffect(shortcut: string | null) {
+    if (!NATIVE_SUPPORT.isProcessForeground.available) {
+      this.context.keyboardShortcuts.unregisterByTargetId(TERMINATE_GAME_CLIENT_SHORTCUT_TARGET_ID)
+      return
+    }
+
     if (shortcut === null) {
       this.context.keyboardShortcuts.unregisterByTargetId(TERMINATE_GAME_CLIENT_SHORTCUT_TARGET_ID)
       return

--- a/src/main/shards/keyboard-shortcuts/context.ts
+++ b/src/main/shards/keyboard-shortcuts/context.ts
@@ -25,6 +25,7 @@ export const DISABLED_KEYS = [
   133, // F22
   13 // Enter
 ]
+export const DISABLED_KEY_IDS = ['F22', 'Enter']
 
 export const COMMON_MODIFIER_VARIANTS: Record<number, number[]> = {
   16: [16, 160, 161],

--- a/src/main/shards/keyboard-shortcuts/electron-global-shortcut-controller.test.ts
+++ b/src/main/shards/keyboard-shortcuts/electron-global-shortcut-controller.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  ElectronGlobalShortcutController,
+  buildActivationShortcutDetails
+} from './electron-global-shortcut-controller'
+
+describe('ElectronGlobalShortcutController', () => {
+  const callbacks = new Map<string, () => void>()
+  const globalShortcut = {
+    register: vi.fn((accelerator: string, callback: () => void) => {
+      callbacks.set(accelerator, callback)
+      return true
+    }),
+    unregister: vi.fn((accelerator: string) => {
+      callbacks.delete(accelerator)
+    }),
+    unregisterAll: vi.fn()
+  }
+  const logger = { info: vi.fn() }
+
+  beforeEach(() => {
+    callbacks.clear()
+    vi.clearAllMocks()
+    globalShortcut.register.mockImplementation((accelerator, callback) => {
+      callbacks.set(accelerator, callback)
+      return true
+    })
+  })
+
+  it('registers and dispatches an activation-only macOS shortcut', () => {
+    const onActivated = vi.fn()
+    const controller = new ElectronGlobalShortcutController(
+      logger,
+      onActivated,
+      globalShortcut,
+      'darwin'
+    )
+
+    controller.register('LeftMeta+Shift+K')
+    callbacks.get('Command+Shift+K')?.()
+
+    expect(onActivated).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'LeftMeta+Shift+K', pressed: true })
+    )
+  })
+
+  it('replaces normalized variants without disturbing the OS registration', () => {
+    const onActivated = vi.fn()
+    const controller = new ElectronGlobalShortcutController(
+      logger,
+      onActivated,
+      globalShortcut,
+      'darwin'
+    )
+
+    controller.register('LeftControl+A')
+    controller.replace('LeftControl+A', 'RightControl+A')
+    callbacks.get('Control+A')?.()
+
+    expect(globalShortcut.register).toHaveBeenCalledOnce()
+    expect(globalShortcut.unregister).not.toHaveBeenCalled()
+    expect(onActivated).toHaveBeenCalledWith(expect.objectContaining({ id: 'RightControl+A' }))
+  })
+
+  it('throws when Electron refuses a registration and keeps prior shortcuts owned', () => {
+    const controller = new ElectronGlobalShortcutController(
+      logger,
+      vi.fn(),
+      globalShortcut,
+      'darwin'
+    )
+    controller.register('LeftMeta+A')
+    globalShortcut.register.mockReturnValueOnce(false)
+
+    expect(() => controller.replace('LeftMeta+A', 'LeftMeta+B')).toThrow(
+      'Electron refused to register global shortcut LeftMeta+B'
+    )
+    expect(callbacks.has('Command+A')).toBe(true)
+  })
+
+  it('unregisters only shortcuts owned by this controller', () => {
+    const controller = new ElectronGlobalShortcutController(
+      logger,
+      vi.fn(),
+      globalShortcut,
+      'darwin'
+    )
+    controller.register('LeftMeta+A')
+    controller.register('LeftMeta+B')
+
+    controller.clear()
+
+    expect(globalShortcut.unregister).toHaveBeenCalledTimes(2)
+    expect(globalShortcut.unregisterAll).not.toHaveBeenCalled()
+  })
+
+  it('reports the adapter unavailable outside macOS', () => {
+    const controller = new ElectronGlobalShortcutController(
+      logger,
+      vi.fn(),
+      globalShortcut,
+      'win32'
+    )
+
+    expect(controller.available).toBe(false)
+    expect(controller.isShortcutIdSupported('Control+A')).toBe(false)
+  })
+
+  it('builds platform-neutral shortcut details without the Win32 addon', () => {
+    expect(buildActivationShortcutDetails('LeftMeta+K')).toEqual(
+      expect.objectContaining({
+        keyCodes: [91, 75],
+        id: 'LeftMeta+K',
+        unifiedId: 'Meta+K'
+      })
+    )
+  })
+})

--- a/src/main/shards/keyboard-shortcuts/electron-global-shortcut-controller.ts
+++ b/src/main/shards/keyboard-shortcuts/electron-global-shortcut-controller.ts
@@ -1,0 +1,162 @@
+import type { ShortcutDetails } from '@shared/shards/keyboard-shortcut'
+import {
+  isActivationShortcutIdSupported,
+  shortcutIdToElectronAccelerator
+} from '@shared/utils/activation-shortcuts'
+import { globalShortcut } from 'electron'
+
+import { UNIFIED_KEY_ID, VKEY_MAP, isModifierKey } from './definitions'
+import { shouldUseElectronGlobalShortcuts } from './platform'
+
+interface ElectronGlobalShortcutApi {
+  register(accelerator: string, callback: () => void): boolean
+  unregister(accelerator: string): void
+}
+
+export interface ActivationShortcutBackend {
+  readonly available: boolean
+  isShortcutIdSupported(shortcutId: string): boolean
+  register(shortcutId: string): void
+  replace(previousShortcutId: string, shortcutId: string): void
+  unregister(shortcutId: string): void
+  clear(): void
+}
+
+const KEY_DEFINITION_BY_ID = new Map(
+  Object.entries(VKEY_MAP).map(([rawKeyCode, definition]) => [
+    definition.keyId,
+    { keyCode: Number(rawKeyCode), definition }
+  ])
+)
+
+export function buildActivationShortcutDetails(shortcutId: string): ShortcutDetails {
+  const keys = shortcutId.split('+').map((keyId) => {
+    const entry = KEY_DEFINITION_BY_ID.get(keyId)
+    if (!entry) {
+      throw new Error(`Unknown activation shortcut key: ${keyId}`)
+    }
+
+    return {
+      keyId,
+      keyCode: entry.keyCode,
+      isModifier: isModifierKey(entry.keyCode)
+    }
+  })
+
+  return {
+    keyCodes: keys.map((key) => key.keyCode),
+    keys,
+    id: shortcutId,
+    unifiedId: [
+      ...new Set(
+        keys.map((key) => UNIFIED_KEY_ID[key.keyCode as keyof typeof UNIFIED_KEY_ID] ?? key.keyId)
+      )
+    ].join('+'),
+    pressed: true
+  }
+}
+
+export class ElectronGlobalShortcutController implements ActivationShortcutBackend {
+  private readonly _acceleratorByShortcutId = new Map<string, string>()
+  private readonly _shortcutIdByAccelerator = new Map<string, string>()
+
+  constructor(
+    private readonly _logger: {
+      info: (...args: any[]) => void
+    },
+    private readonly _onActivated: (details: ShortcutDetails) => void,
+    private readonly _globalShortcut: ElectronGlobalShortcutApi = globalShortcut,
+    private readonly _platform: NodeJS.Platform = process.platform
+  ) {}
+
+  get available() {
+    return shouldUseElectronGlobalShortcuts(this._platform)
+  }
+
+  isShortcutIdSupported(shortcutId: string) {
+    return this.available && isActivationShortcutIdSupported(shortcutId)
+  }
+
+  register(shortcutId: string) {
+    if (!this.available) {
+      throw new Error('Electron global shortcuts are unavailable on this platform')
+    }
+
+    const accelerator = shortcutIdToElectronAccelerator(shortcutId)
+    if (!accelerator) {
+      throw new Error(`Shortcut ${shortcutId} is not supported by Electron global shortcuts`)
+    }
+
+    const existingAccelerator = this._acceleratorByShortcutId.get(shortcutId)
+    if (existingAccelerator === accelerator) {
+      return
+    }
+
+    const existingShortcutId = this._shortcutIdByAccelerator.get(accelerator)
+    if (existingShortcutId && existingShortcutId !== shortcutId) {
+      throw new Error(
+        `Shortcut ${shortcutId} conflicts with registered shortcut ${existingShortcutId}`
+      )
+    }
+
+    const registered = this._globalShortcut.register(accelerator, () => {
+      const activeShortcutId = this._shortcutIdByAccelerator.get(accelerator)
+      if (activeShortcutId) {
+        this._onActivated(buildActivationShortcutDetails(activeShortcutId))
+      }
+    })
+
+    if (!registered) {
+      throw new Error(`Electron refused to register global shortcut ${shortcutId}`)
+    }
+
+    this._acceleratorByShortcutId.set(shortcutId, accelerator)
+    this._shortcutIdByAccelerator.set(accelerator, shortcutId)
+    this._logger.info(`Registered Electron global shortcut ${shortcutId} (${accelerator})`)
+  }
+
+  replace(previousShortcutId: string, shortcutId: string) {
+    const previousAccelerator = this._acceleratorByShortcutId.get(previousShortcutId)
+    const accelerator = shortcutIdToElectronAccelerator(shortcutId)
+
+    if (!previousAccelerator) {
+      this.register(shortcutId)
+      return
+    }
+
+    if (!accelerator) {
+      throw new Error(`Shortcut ${shortcutId} is not supported by Electron global shortcuts`)
+    }
+
+    if (previousAccelerator === accelerator) {
+      this._acceleratorByShortcutId.delete(previousShortcutId)
+      this._acceleratorByShortcutId.set(shortcutId, accelerator)
+      this._shortcutIdByAccelerator.set(accelerator, shortcutId)
+      return
+    }
+
+    this.register(shortcutId)
+    this.unregister(previousShortcutId)
+  }
+
+  unregister(shortcutId: string) {
+    const accelerator = this._acceleratorByShortcutId.get(shortcutId)
+    if (!accelerator) {
+      return
+    }
+
+    this._globalShortcut.unregister(accelerator)
+    this._acceleratorByShortcutId.delete(shortcutId)
+    this._shortcutIdByAccelerator.delete(accelerator)
+    this._logger.info(`Unregistered Electron global shortcut ${shortcutId} (${accelerator})`)
+  }
+
+  clear() {
+    for (const accelerator of this._shortcutIdByAccelerator.keys()) {
+      this._globalShortcut.unregister(accelerator)
+    }
+
+    this._acceleratorByShortcutId.clear()
+    this._shortcutIdByAccelerator.clear()
+  }
+}

--- a/src/main/shards/keyboard-shortcuts/index.test.ts
+++ b/src/main/shards/keyboard-shortcuts/index.test.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { KeyboardShortcutsMain } from './index'
 
@@ -9,6 +9,8 @@ const nativeInputMock = vi.hoisted(() => {
 
   return {
     pressed,
+    on: vi.fn(),
+    off: vi.fn(),
     getKeyStates: vi.fn(() =>
       Array.from({ length: 256 }, (_, vkCode) => ({
         vkCode,
@@ -18,6 +20,39 @@ const nativeInputMock = vi.hoisted(() => {
     )
   }
 })
+
+const nativeSupportMock = vi.hoisted(() => ({
+  nativeInput: {
+    available: true,
+    availableOnCurrentPlatform: true,
+    requiresElevation: true
+  },
+  activationShortcut: {
+    available: true,
+    availableOnCurrentPlatform: true,
+    requiresElevation: false
+  }
+}))
+
+const globalShortcutMock = vi.hoisted(() => {
+  const callbacks = new Map<string, () => void>()
+
+  return {
+    callbacks,
+    register: vi.fn((accelerator: string, callback: () => void) => {
+      callbacks.set(accelerator, callback)
+      return true
+    }),
+    unregister: vi.fn((accelerator: string) => {
+      callbacks.delete(accelerator)
+    }),
+    unregisterAll: vi.fn()
+  }
+})
+
+vi.mock('electron', () => ({
+  globalShortcut: globalShortcutMock
+}))
 
 vi.mock('@main/native', () => {
   const VKEY_MAP = {
@@ -32,13 +67,7 @@ vi.mock('@main/native', () => {
   }
 
   return {
-    NATIVE_SUPPORT: {
-      nativeInput: {
-        available: true,
-        availableOnCurrentPlatform: true,
-        requiresElevation: true
-      }
-    },
+    NATIVE_SUPPORT: nativeSupportMock,
     nativeInput: {
       VKEY_MAP,
       UNIFIED_KEY_ID: {
@@ -48,7 +77,8 @@ vi.mock('@main/native', () => {
       },
       isModifierKey: (keyCode: number) => [17, 162, 163].includes(keyCode),
       instance: {
-        on: vi.fn(),
+        on: nativeInputMock.on,
+        off: nativeInputMock.off,
         getKeyStates: nativeInputMock.getKeyStates
       }
     }
@@ -96,8 +126,85 @@ function emitKey(kbd: KeyboardShortcutsMain, event: TestKeyEvent) {
 
 describe('KeyboardShortcutsMain', () => {
   beforeEach(() => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+    nativeSupportMock.nativeInput.available = true
+    nativeSupportMock.activationShortcut.available = true
     nativeInputMock.pressed.clear()
+    nativeInputMock.on.mockClear()
+    nativeInputMock.off.mockClear()
     nativeInputMock.getKeyStates.mockClear()
+    globalShortcutMock.callbacks.clear()
+    globalShortcutMock.register.mockClear()
+    globalShortcutMock.register.mockImplementation((accelerator, callback) => {
+      globalShortcutMock.callbacks.set(accelerator, callback)
+      return true
+    })
+    globalShortcutMock.unregister.mockClear()
+    globalShortcutMock.unregisterAll.mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('uses Electron for normal shortcuts when native input is unavailable on macOS', async () => {
+    nativeSupportMock.nativeInput.available = false
+    const kbd = createKeyboardShortcuts()
+    const callback = vi.fn()
+
+    kbd.register('macos-shortcut', 'LeftMeta+A', 'normal', callback)
+    await kbd.onInit()
+    globalShortcutMock.callbacks.get('Command+A')?.()
+
+    expect(kbd.getRegistration('LeftMeta+A')).toEqual(
+      expect.objectContaining({ targetId: 'macos-shortcut', type: 'normal' })
+    )
+    expect(callback).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'LeftMeta+A', pressed: true })
+    )
+    expect(nativeInputMock.on).not.toHaveBeenCalled()
+  })
+
+  it('leaves stateful and last-active shortcuts unavailable without native input', () => {
+    nativeSupportMock.nativeInput.available = false
+    const kbd = createKeyboardShortcuts()
+
+    kbd.register('stateful', 'LeftMeta+A', 'stateful', vi.fn())
+    kbd.register('last-active', 'LeftMeta+B', 'last-active', vi.fn())
+
+    expect(kbd.getRegistrationByTargetId('stateful')).toBeNull()
+    expect(kbd.getRegistrationByTargetId('last-active')).toBeNull()
+    expect(globalShortcutMock.register).not.toHaveBeenCalled()
+  })
+
+  it('rejects reserved and non-Electron activation shortcuts on macOS', () => {
+    nativeSupportMock.nativeInput.available = false
+    const kbd = createKeyboardShortcuts()
+
+    expect(() => kbd.register('reserved', 'LeftMeta+Enter', 'normal', vi.fn())).toThrow(
+      'contains reserved keys'
+    )
+    expect(() => kbd.register('unsupported', 'LeftMeta+Numpad1', 'normal', vi.fn())).toThrow(
+      'unavailable for activation-only shortcuts'
+    )
+    expect(kbd.getRegistration('LeftMeta+Enter')).toEqual(
+      expect.objectContaining({ targetId: KeyboardShortcutsMain.DISABLED_KEYS_TARGET_ID })
+    )
+    expect(kbd.getRegistration('LeftMeta+Numpad1')).toEqual(
+      expect.objectContaining({ targetId: KeyboardShortcutsMain.DISABLED_KEYS_TARGET_ID })
+    )
+  })
+
+  it('keeps the Windows native registration path unchanged', () => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    const kbd = createKeyboardShortcuts()
+    const callback = vi.fn()
+
+    kbd.register('windows-shortcut', 'A', 'normal', callback)
+    emitKey(kbd, { keyCode: 65, isDown: true, isModifier: false })
+
+    expect(callback).toHaveBeenCalledOnce()
+    expect(globalShortcutMock.register).not.toHaveBeenCalled()
   })
 
   it('recovers when a side-specific modifier is released as a common modifier event', () => {

--- a/src/main/shards/keyboard-shortcuts/index.ts
+++ b/src/main/shards/keyboard-shortcuts/index.ts
@@ -21,6 +21,7 @@ import {
   MODIFIER_READING_ORDER,
   VK_CODE_F22
 } from './context'
+import { ElectronGlobalShortcutController } from './electron-global-shortcut-controller'
 import { KeyboardShortcutsIpcHandlers } from './ipc-handlers'
 import { ShortcutRegistry } from './shortcut-registry'
 
@@ -34,6 +35,7 @@ export class KeyboardShortcutsMain implements IAkariShardInitDispose {
 
   private readonly _logger: AkariLogger
   private readonly _context: KeyboardShortcutsMainContext
+  private readonly _electronGlobalShortcuts: ElectronGlobalShortcutController
   private readonly _registry: ShortcutRegistry
   private readonly _ipcHandlers: KeyboardShortcutsIpcHandlers
 
@@ -89,7 +91,10 @@ export class KeyboardShortcutsMain implements IAkariShardInitDispose {
       ipc: _ipc,
       logger: this._logger
     }
-    this._registry = new ShortcutRegistry(this._logger)
+    this._electronGlobalShortcuts = new ElectronGlobalShortcutController(this._logger, (details) =>
+      this._processActivationShortcut(details)
+    )
+    this._registry = new ShortcutRegistry(this._logger, this._electronGlobalShortcuts)
     this._ipcHandlers = new KeyboardShortcutsIpcHandlers(this._context, this)
   }
 
@@ -352,6 +357,17 @@ export class KeyboardShortcutsMain implements IAkariShardInitDispose {
     this._emitLastActiveShortcutIfNeeded()
   }
 
+  private _processActivationShortcut(details: ShortcutDetails) {
+    const registration = this._registry.getActiveRegistration(details.id)
+    if (!registration || registration.type !== 'normal') {
+      return
+    }
+
+    this.events.emit('shortcut', details)
+    registration.cb(details)
+    this._ipc.sendEvent(KeyboardShortcutsMain.id, 'shortcut', details)
+  }
+
   async onInit() {
     if (NATIVE_SUPPORT.nativeInput.available) {
       this._logger.info('Listening for key events')
@@ -359,6 +375,8 @@ export class KeyboardShortcutsMain implements IAkariShardInitDispose {
         this._processNativeKeyEvent(key)
       }
       nativeInput.instance.on('keyEvent', this._nativeKeyEventHandler)
+    } else if (this._electronGlobalShortcuts.available) {
+      this._logger.info('Using Electron activation-only global shortcuts')
     }
 
     this._ipcHandlers.register()

--- a/src/main/shards/keyboard-shortcuts/platform.test.ts
+++ b/src/main/shards/keyboard-shortcuts/platform.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldUseElectronGlobalShortcuts } from './platform'
+
+describe('keyboard shortcut platform adapter', () => {
+  it('uses Electron global shortcuts only for the macOS adapter', () => {
+    expect(shouldUseElectronGlobalShortcuts('darwin')).toBe(true)
+    expect(shouldUseElectronGlobalShortcuts('win32')).toBe(false)
+    expect(shouldUseElectronGlobalShortcuts('linux')).toBe(false)
+  })
+})

--- a/src/main/shards/keyboard-shortcuts/platform.ts
+++ b/src/main/shards/keyboard-shortcuts/platform.ts
@@ -1,0 +1,3 @@
+export function shouldUseElectronGlobalShortcuts(platform: NodeJS.Platform = process.platform) {
+  return platform === 'darwin'
+}

--- a/src/main/shards/keyboard-shortcuts/shortcut-registry.ts
+++ b/src/main/shards/keyboard-shortcuts/shortcut-registry.ts
@@ -1,12 +1,13 @@
-import { NATIVE_SUPPORT, nativeInput } from '@main/native'
+import { NATIVE_SUPPORT } from '@main/native'
 import { isSupportedShortcutId } from '@shared/utils/keyboard-shortcuts'
 
 import {
-  DISABLED_KEYS,
   DISABLED_KEYS_TARGET_ID,
+  DISABLED_KEY_IDS,
   type KeyboardShortcutRegistration,
   type KeyboardShortcutRegistrationType
 } from './context'
+import type { ActivationShortcutBackend } from './electron-global-shortcut-controller'
 
 export class ShortcutRegistry {
   private readonly registrationMap = new Map<string, KeyboardShortcutRegistration>()
@@ -15,7 +16,8 @@ export class ShortcutRegistry {
   constructor(
     private readonly logger: {
       info: (...args: any[]) => void
-    }
+    },
+    private readonly activationShortcutBackend: ActivationShortcutBackend
   ) {}
 
   register(
@@ -24,15 +26,31 @@ export class ShortcutRegistry {
     type: KeyboardShortcutRegistrationType,
     cb: KeyboardShortcutRegistration['cb']
   ) {
-    if (!NATIVE_SUPPORT.nativeInput.available) {
-      this.logger.info(
-        `Native global shortcuts are unavailable, ignoring shortcut registration: ${shortcutId} (${type})`
-      )
+    const usesNativeInput = NATIVE_SUPPORT.nativeInput.available
+    const usesActivationShortcut =
+      !usesNativeInput && type === 'normal' && this.activationShortcutBackend.available
+
+    if (!usesNativeInput && !usesActivationShortcut) {
+      this.logger.info(`Shortcut type ${type} is unavailable, ignoring registration: ${shortcutId}`)
       return
     }
 
     if (!isSupportedShortcutId(shortcutId)) {
       throw new Error(`Shortcut ${shortcutId} contains unsupported keys`)
+    }
+
+    if (
+      usesActivationShortcut &&
+      !this.activationShortcutBackend.isShortcutIdSupported(shortcutId)
+    ) {
+      throw new Error(`Shortcut ${shortcutId} is unavailable for activation-only shortcuts`)
+    }
+
+    if (
+      usesActivationShortcut &&
+      DISABLED_KEY_IDS.some((keyId) => shortcutId.split('+').includes(keyId))
+    ) {
+      throw new Error(`Shortcut ${shortcutId} contains reserved keys`)
     }
 
     const existingShortcutRegistration = this.registrationMap.get(shortcutId)
@@ -43,6 +61,14 @@ export class ShortcutRegistry {
     }
 
     const originShortcut = this.targetIdMap.get(targetId)
+    if (usesActivationShortcut) {
+      if (originShortcut && originShortcut !== shortcutId) {
+        this.activationShortcutBackend.replace(originShortcut, shortcutId)
+      } else if (!existingShortcutRegistration) {
+        this.activationShortcutBackend.register(shortcutId)
+      }
+    }
+
     if (originShortcut && originShortcut !== shortcutId) {
       this.registrationMap.delete(originShortcut)
     }
@@ -58,6 +84,10 @@ export class ShortcutRegistry {
       return false
     }
 
+    if (this.activationShortcutBackend.available && options.type === 'normal') {
+      this.activationShortcutBackend.unregister(shortcutId)
+    }
+
     this.registrationMap.delete(shortcutId)
     this.targetIdMap.delete(options.targetId)
     this.logger.info(`Unregister shortcut ${shortcutId} for target ${options.targetId}`)
@@ -70,6 +100,15 @@ export class ShortcutRegistry {
       return false
     }
 
+    const registration = this.registrationMap.get(shortcutId)
+    if (
+      registration &&
+      this.activationShortcutBackend.available &&
+      registration.type === 'normal'
+    ) {
+      this.activationShortcutBackend.unregister(shortcutId)
+    }
+
     this.registrationMap.delete(shortcutId)
     this.targetIdMap.delete(targetId)
     this.logger.info(`Unregister shortcut ${shortcutId} for target ${targetId}`)
@@ -77,17 +116,15 @@ export class ShortcutRegistry {
   }
 
   getRegistration(shortcutId: string) {
-    if (!NATIVE_SUPPORT.nativeInput.available) {
+    if (!NATIVE_SUPPORT.nativeInput.available && !this.activationShortcutBackend.available) {
       return null
     }
 
-    const reservedKeyIds = DISABLED_KEYS.map(
-      (keyCode) => nativeInput.VKEY_MAP[keyCode]?.keyId
-    ).filter((keyId): keyId is string => Boolean(keyId))
-
     if (
-      reservedKeyIds.some((keyId) => shortcutId.includes(keyId)) ||
-      !isSupportedShortcutId(shortcutId)
+      DISABLED_KEY_IDS.some((keyId) => shortcutId.split('+').includes(keyId)) ||
+      !isSupportedShortcutId(shortcutId) ||
+      (!NATIVE_SUPPORT.nativeInput.available &&
+        !this.activationShortcutBackend.isShortcutIdSupported(shortcutId))
     ) {
       return {
         type: 'normal',
@@ -123,6 +160,7 @@ export class ShortcutRegistry {
   }
 
   clear() {
+    this.activationShortcutBackend.clear()
     this.registrationMap.clear()
     this.targetIdMap.clear()
   }

--- a/src/main/shards/league-client-ux/context.ts
+++ b/src/main/shards/league-client-ux/context.ts
@@ -2,13 +2,14 @@ import type { AkariIpcMain } from '../ipc'
 import type { AkariLogger } from '../logger-factory'
 import type { MobxUtilsMain } from '../mobx-utils'
 import type { SetterSettingService } from '../setting-factory/setter-setting-service'
+import { getConnectedClientCommandLinePollInterval } from './platform'
 import type { LeagueClientUxSettings, LeagueClientUxState } from './state'
 
 export const LEAGUE_CLIENT_UX_MAIN_NAMESPACE = 'league-client-ux-main'
 export const LEAGUE_CLIENT_UX_PROCESS_NAME =
   process.platform === 'win32' ? 'LeagueClientUx.exe' : 'LeagueClientUx'
 export const CLIENT_CMD_DEFAULT_POLL_INTERVAL = 2000
-export const CLIENT_CMD_LONG_POLL_INTERVAL = 60 * 1000
+export const CLIENT_CMD_LONG_POLL_INTERVAL = getConnectedClientCommandLinePollInterval()
 
 export interface LeagueClientUxMainContext {
   namespace: string

--- a/src/main/shards/league-client-ux/index.test.ts
+++ b/src/main/shards/league-client-ux/index.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { LeagueClientUxMain } from '.'
+
+const nativeMocks = vi.hoisted(() => ({
+  getCommandLine: vi.fn(),
+  getPidsByName: vi.fn(async () => [] as number[])
+}))
+
+vi.mock('@main/native', () => ({
+  getCommandLine: nativeMocks.getCommandLine,
+  getPidsByName: nativeMocks.getPidsByName,
+  isElevated: false
+}))
+
+vi.mock('@resources/elevate.exe?asset&asarUnpack', () => ({ default: '/synthetic/elevate.exe' }))
+vi.mock('@resources/rebuild_WMI.bat?asset&asarUnpack', () => ({
+  default: '/synthetic/rebuild_WMI.bat'
+}))
+vi.mock('../ipc', () => ({ AkariIpcMain: class AkariIpcMain {} }))
+vi.mock('../logger-factory', () => ({
+  AkariLogger: class AkariLogger {},
+  LoggerFactoryMain: class LoggerFactoryMain {}
+}))
+vi.mock('../mobx-utils', () => ({ MobxUtilsMain: class MobxUtilsMain {} }))
+vi.mock('../setting-factory', () => ({ SettingFactoryMain: class SettingFactoryMain {} }))
+
+function createLeagueClientUxMain() {
+  const ipc = {
+    onCall: vi.fn(),
+    sendEvent: vi.fn()
+  }
+  const logger = {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn()
+  }
+  const loggerFactory = {
+    create: vi.fn(() => logger)
+  }
+  const settingService = {
+    applyToState: vi.fn(async () => undefined),
+    set: vi.fn()
+  }
+  const settingFactory = {
+    register: vi.fn(() => settingService)
+  }
+  const mobxUtils = {
+    propSync: vi.fn()
+  }
+
+  return new LeagueClientUxMain(
+    ipc as any,
+    loggerFactory as any,
+    settingFactory as any,
+    mobxUtils as any
+  )
+}
+
+describe('LeagueClientUxMain polling', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    nativeMocks.getPidsByName.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('keeps the selected interval after consecutive successful reads', async () => {
+    const leagueClientUx = createLeagueClientUxMain()
+    await leagueClientUx.onInit()
+    await vi.advanceTimersByTimeAsync(0)
+    nativeMocks.getPidsByName.mockClear()
+
+    leagueClientUx.setPollInterval(5_000)
+
+    await vi.advanceTimersByTimeAsync(4_999)
+    expect(nativeMocks.getPidsByName).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(nativeMocks.getPidsByName).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(nativeMocks.getPidsByName).toHaveBeenCalledTimes(2)
+
+    await leagueClientUx.onDispose()
+  })
+})

--- a/src/main/shards/league-client-ux/index.ts
+++ b/src/main/shards/league-client-ux/index.ts
@@ -43,6 +43,8 @@ export class LeagueClientUxMain implements IAkariShardInitDispose {
   private readonly _commandLineReader: LeagueClientUxCommandLineReader
 
   private _pollTimerId: NodeJS.Timeout | null = null
+  private _pollInterval = LeagueClientUxMain.CLIENT_CMD_DEFAULT_POLL_INTERVAL
+  private _isPolling = false
 
   constructor(
     private readonly _ipc: AkariIpcMain,
@@ -79,21 +81,25 @@ export class LeagueClientUxMain implements IAkariShardInitDispose {
   }
 
   async onDispose() {
+    this._isPolling = false
     if (this._pollTimerId) {
-      clearInterval(this._pollTimerId)
+      clearTimeout(this._pollTimerId)
       this._pollTimerId = null
     }
   }
 
   setPollInterval(interval: number, immediate = false) {
+    this._pollInterval = interval
+
     if (this._pollTimerId) {
-      clearInterval(this._pollTimerId)
+      clearTimeout(this._pollTimerId)
+      this._pollTimerId = null
+    }
 
-      if (immediate) {
-        this.update()
-      }
-
-      this._pollTimerId = setInterval(() => this.update(), interval)
+    if (immediate) {
+      void this.update()
+    } else {
+      this._scheduleNextPoll()
     }
   }
 
@@ -103,17 +109,11 @@ export class LeagueClientUxMain implements IAkariShardInitDispose {
   async update() {
     try {
       this.state.setLaunchedClients(await this._commandLineReader.read())
-
-      if (this._pollTimerId) {
-        clearInterval(this._pollTimerId)
-      }
-      this._pollTimerId = setInterval(
-        () => this.update(),
-        LeagueClientUxMain.CLIENT_CMD_DEFAULT_POLL_INTERVAL
-      )
     } catch (error) {
       this._ipc.sendEvent(LeagueClientUxMain.id, 'error-polling')
       this._logger.error(`Failed to get Ux command line`, error)
+    } finally {
+      this._scheduleNextPoll()
     }
   }
 
@@ -141,10 +141,22 @@ export class LeagueClientUxMain implements IAkariShardInitDispose {
   }
 
   private _watchExistingUx() {
-    this.update()
-    this._pollTimerId = setInterval(
-      () => this.update(),
-      LeagueClientUxMain.CLIENT_CMD_DEFAULT_POLL_INTERVAL
-    )
+    this._isPolling = true
+    void this.update()
+  }
+
+  private _scheduleNextPoll() {
+    if (!this._isPolling) {
+      return
+    }
+
+    if (this._pollTimerId) {
+      clearTimeout(this._pollTimerId)
+    }
+
+    this._pollTimerId = setTimeout(() => {
+      this._pollTimerId = null
+      void this.update()
+    }, this._pollInterval)
   }
 }

--- a/src/main/shards/league-client-ux/platform.test.ts
+++ b/src/main/shards/league-client-ux/platform.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'vitest'
+
+import { getConnectedClientCommandLinePollInterval } from './platform'
+
+describe('League Client UX platform behavior', () => {
+  test('polls connected macOS clients often enough to observe restarted Riot credentials', () => {
+    expect(getConnectedClientCommandLinePollInterval('darwin')).toBe(5_000)
+  })
+
+  test('preserves the existing Windows connected poll interval', () => {
+    expect(getConnectedClientCommandLinePollInterval('win32')).toBe(60_000)
+  })
+})

--- a/src/main/shards/league-client-ux/platform.ts
+++ b/src/main/shards/league-client-ux/platform.ts
@@ -1,0 +1,10 @@
+const DEFAULT_CONNECTED_COMMAND_LINE_POLL_INTERVAL = 60 * 1000
+const DARWIN_CONNECTED_COMMAND_LINE_POLL_INTERVAL = 5 * 1000
+
+export function getConnectedClientCommandLinePollInterval(
+  platform: NodeJS.Platform = process.platform
+) {
+  return platform === 'darwin'
+    ? DARWIN_CONNECTED_COMMAND_LINE_POLL_INTERVAL
+    : DEFAULT_CONNECTED_COMMAND_LINE_POLL_INTERVAL
+}

--- a/src/main/shards/league-client-ux/ux-command-line-parser.test.ts
+++ b/src/main/shards/league-client-ux/ux-command-line-parser.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'vitest'
+
+import { parseCommandLine, parseUxCommandLinePaths } from './ux-command-line-parser'
+
+describe('League Client UX command-line parsing', () => {
+  test('parses connection values and macOS directories from a spaced command line', () => {
+    const commandLine =
+      '/Applications/League of Legends.app/Contents/LoL/League of Legends.app/Contents/MacOS/LeagueClientUx ' +
+      '--app-port 54321 --remoting-auth-token="synthetic.lcu_token-1" --app-pid=4242 ' +
+      '--rso_platform_id=EUW1 --region=euw --riotclient-app-port=61234 ' +
+      '--riotclient-auth-token=synthetic-riot_token.2 ' +
+      '--install-directory=/Applications/League of Legends.app/Contents/LoL ' +
+      '--app-directory="/Applications/League of Legends.app/Contents/LoL/League of Legends.app"'
+
+    expect(parseCommandLine(commandLine)).toMatchObject({
+      port: 54321,
+      pid: 4242,
+      authToken: 'synthetic.lcu_token-1',
+      rsoPlatformId: 'EUW1',
+      region: 'euw',
+      riotClientPort: 61234,
+      riotClientAuthToken: 'synthetic-riot_token.2'
+    })
+    expect(parseUxCommandLinePaths(commandLine)).toEqual({
+      installationDirectory: '/Applications/League of Legends.app/Contents/LoL',
+      applicationDirectory: '/Applications/League of Legends.app/Contents/LoL/League of Legends.app'
+    })
+  })
+
+  test('accepts the hyphenated RSO platform option', () => {
+    expect(
+      parseCommandLine(
+        'LeagueClientUx --app-port=12345 --remoting-auth-token=synthetic-token ' +
+          '--app-pid=123 --rso-platform-id=NA1'
+      )
+    ).toMatchObject({ rsoPlatformId: 'NA1' })
+  })
+
+  test('rejects a command line missing any required LCU connection value', () => {
+    expect(parseCommandLine('LeagueClientUx --app-port=12345 --app-pid=123')).toBeNull()
+    expect(
+      parseCommandLine(
+        'LeagueClientUx --app-port=not-a-port --remoting-auth-token=synthetic-token --app-pid=123'
+      )
+    ).toBeNull()
+    expect(
+      parseCommandLine(
+        'LeagueClientUx --app-port=65536 --remoting-auth-token=synthetic-token --app-pid=123'
+      )
+    ).toBeNull()
+  })
+})

--- a/src/main/shards/league-client-ux/ux-command-line-parser.ts
+++ b/src/main/shards/league-client-ux/ux-command-line-parser.ts
@@ -1,3 +1,4 @@
+import { getProcessCommandLineOption } from '@main/native/process-command-line'
 import { UxCommandLine } from '@shared/shards/league-client-ux'
 
 /**
@@ -29,36 +30,63 @@ EcGfKZ+g024k/J32XP4hdho7WYAS2xMiV83CfLR/MNi8oSMaVQTdKD8cpgiWJk3L
 XWehWA==
 -----END CERTIFICATE-----`
 
-const portRegex = /--app-port=([0-9]+)/
-const remotingAuth = /--remoting-auth-token=([\w-_]+)/
-const pidRegex = /--app-pid=([0-9]+)/
-// Some clients use `--rso_platform_id`, others use `--rso-platform-id`.
-const rsoPlatformIdRegex = /--rso[_-]platform[_-]id=([\w-_]+)/i
-const regionRegex = /--region=([\w-_]+)/
-const riotClientPortRegex = /--riotclient-app-port=([0-9]+)/
-const riotClientAuthRegex = /--riotclient-auth-token=([\w-_]+)/
+export interface UxCommandLinePaths {
+  applicationDirectory: string | null
+  installationDirectory: string | null
+}
+
+function getNumericOption(commandLine: string, names: string | readonly string[]) {
+  const value = getProcessCommandLineOption(commandLine, names)
+  if (!value || !/^\d+$/.test(value)) {
+    return null
+  }
+
+  const number = Number(value)
+  return Number.isSafeInteger(number) ? number : null
+}
+
+function getPortOption(commandLine: string, name: string) {
+  const port = getNumericOption(commandLine, name)
+  return port !== null && port > 0 && port <= 65_535 ? port : null
+}
+
+export function parseUxCommandLinePaths(commandLine: string): UxCommandLinePaths {
+  return {
+    applicationDirectory:
+      getProcessCommandLineOption(commandLine, ['app-directory', 'app_directory', 'app-root']) ??
+      null,
+    installationDirectory:
+      getProcessCommandLineOption(commandLine, [
+        'install-directory',
+        'install_directory',
+        'product-install-path',
+        'product_install_full_path'
+      ]) ?? null
+  }
+}
 
 export function parseCommandLine(s: string): UxCommandLine | null {
-  const [, port] = s.match(portRegex) || []
-  const [, password] = s.match(remotingAuth) || []
-  const [, pid] = s.match(pidRegex) || []
-  const [, rsoPlatformId = ''] = s.match(rsoPlatformIdRegex) || []
-  const [, region = ''] = s.match(regionRegex) || []
-  const [, riotClientPort = ''] = s.match(riotClientPortRegex) || []
-  const [, riotClientAuth = ''] = s.match(riotClientAuthRegex) || []
+  const port = getPortOption(s, 'app-port')
+  const password = getProcessCommandLineOption(s, 'remoting-auth-token')
+  const pid = getNumericOption(s, 'app-pid')
+  // Some clients use `--rso_platform_id`, others use `--rso-platform-id`.
+  const rsoPlatformId = getProcessCommandLineOption(s, ['rso_platform_id', 'rso-platform-id']) ?? ''
+  const region = getProcessCommandLineOption(s, 'region') ?? ''
+  const riotClientPort = getPortOption(s, 'riotclient-app-port') ?? 0
+  const riotClientAuth = getProcessCommandLineOption(s, 'riotclient-auth-token') ?? ''
 
-  if (!port || !password || !pid) {
+  if (port === null || !password || pid === null || pid <= 0) {
     return null
   }
 
   return {
-    port: Number(port),
-    pid: Number(pid),
+    port,
+    pid,
     authToken: password,
     rsoPlatformId,
     region,
     certificate: RIOT_CERTIFICATE,
-    riotClientPort: Number(riotClientPort),
+    riotClientPort,
     riotClientAuthToken: riotClientAuth
   }
 }

--- a/src/main/shards/league-client/client-auth.test.ts
+++ b/src/main/shards/league-client/client-auth.test.ts
@@ -1,0 +1,47 @@
+import type { UxCommandLine } from '@shared/shards/league-client-ux'
+import { describe, expect, it } from 'vitest'
+
+import { classifyClientCredentialChange, getClientAuthLogMetadata } from './client-auth'
+
+function createAuth(overrides: Partial<UxCommandLine> = {}): UxCommandLine {
+  return {
+    authToken: 'synthetic-lcu-token',
+    certificate: 'synthetic-certificate',
+    pid: 123,
+    port: 456,
+    region: 'EUW',
+    riotClientAuthToken: 'synthetic-riot-token',
+    riotClientPort: 789,
+    rsoPlatformId: 'EUW1',
+    ...overrides
+  }
+}
+
+describe('client credential lifecycle', () => {
+  it('distinguishes Riot restarts from League restarts', () => {
+    const current = createAuth()
+
+    expect(
+      classifyClientCredentialChange(
+        current,
+        createAuth({ riotClientAuthToken: 'replacement-riot-token', riotClientPort: 790 })
+      )
+    ).toBe('riot-client')
+    expect(
+      classifyClientCredentialChange(
+        current,
+        createAuth({ authToken: 'replacement-lcu-token', port: 457 })
+      )
+    ).toBe('league-client')
+    expect(classifyClientCredentialChange(current, createAuth())).toBe('none')
+  })
+
+  it('never includes credentials in log metadata', () => {
+    const metadata = getClientAuthLogMetadata(createAuth())
+
+    expect(metadata).not.toHaveProperty('authToken')
+    expect(metadata).not.toHaveProperty('riotClientAuthToken')
+    expect(metadata).not.toHaveProperty('certificate')
+    expect(metadata).toMatchObject({ pid: 123, port: 456, riotClientPort: 789 })
+  })
+})

--- a/src/main/shards/league-client/client-auth.ts
+++ b/src/main/shards/league-client/client-auth.ts
@@ -1,0 +1,32 @@
+import type { UxCommandLine } from '@shared/shards/league-client-ux'
+
+export type ClientCredentialChange = 'none' | 'riot-client' | 'league-client'
+
+export function classifyClientCredentialChange(
+  current: UxCommandLine,
+  next: UxCommandLine
+): ClientCredentialChange {
+  if (current.port !== next.port || current.authToken !== next.authToken) {
+    return 'league-client'
+  }
+
+  if (
+    current.riotClientPort !== next.riotClientPort ||
+    current.riotClientAuthToken !== next.riotClientAuthToken
+  ) {
+    return 'riot-client'
+  }
+
+  return 'none'
+}
+
+export function getClientAuthLogMetadata(auth: UxCommandLine) {
+  const {
+    authToken: _authToken,
+    certificate: _certificate,
+    riotClientAuthToken: _riotToken,
+    ...rest
+  } = auth
+
+  return rest
+}

--- a/src/main/shards/league-client/connection-lifecycle.test.ts
+++ b/src/main/shards/league-client/connection-lifecycle.test.ts
@@ -1,0 +1,132 @@
+import 'reflect-metadata'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { LeagueClientMain } from '.'
+
+vi.mock('@main/native', () => ({
+  NATIVE_SUPPORT: {
+    adjustLeagueClientWindowSize: { available: false }
+  },
+  adjustLeagueClientWindowSize: vi.fn(),
+  getPidsByName: vi.fn(async () => [])
+}))
+vi.mock('../akari-protocol', () => ({ AkariProtocolMain: class AkariProtocolMain {} }))
+vi.mock('../ipc', () => ({ AkariIpcMain: class AkariIpcMain {} }))
+vi.mock('../league-client-ux', () => ({ LeagueClientUxMain: class LeagueClientUxMain {} }))
+vi.mock('../logger-factory', () => ({
+  AkariLogger: class AkariLogger {},
+  LoggerFactoryMain: class LoggerFactoryMain {}
+}))
+vi.mock('../mobx-utils', () => ({ MobxUtilsMain: class MobxUtilsMain {} }))
+vi.mock('../setting-factory', () => ({ SettingFactoryMain: class SettingFactoryMain {} }))
+vi.mock('./ipc-handlers', () => ({ LeagueClientIpcHandlers: class LeagueClientIpcHandlers {} }))
+vi.mock('./lc-state', () => ({ LeagueClientData: class LeagueClientData {} }))
+
+function createConnectionLoopHarness() {
+  const target = {
+    pid: 4242,
+    port: 54321,
+    authToken: 'synthetic-lcu-token_DO_NOT_USE',
+    certificate: 'synthetic-certificate',
+    region: 'euw',
+    rsoPlatformId: 'EUW1',
+    riotClientPort: 61234,
+    riotClientAuthToken: 'synthetic-riot-token_DO_NOT_USE'
+  }
+  const state = {
+    connectionState: 'disconnected',
+    connectingClient: target as typeof target | null,
+    setConnectingClient: vi.fn((value: typeof target | null) => {
+      state.connectingClient = value
+    }),
+    setConnected: vi.fn(() => {
+      state.connectionState = 'connected'
+    }),
+    setConnecting: vi.fn(() => {
+      state.connectionState = 'connecting'
+    }),
+    setDisconnected: vi.fn(() => {
+      state.connectionState = 'disconnected'
+    })
+  }
+  const client = Object.create(LeagueClientMain.prototype) as any
+  Object.assign(client, {
+    _connectToLcu: vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error('LCU is still starting'), { status: 401 }))
+      .mockResolvedValueOnce(undefined),
+    _ipc: { sendEvent: vi.fn() },
+    _leagueClientUx: { state: { launchedClients: [target] } },
+    _logger: { info: vi.fn(), warn: vi.fn() },
+    _manuallyDisconnected: false,
+    _connectionAttemptId: 0,
+    _isConnectionLoopRunning: false,
+    _shouldHaveOneAttempt: false,
+    state
+  })
+
+  return { client, state, target }
+}
+
+describe('League Client connection lifecycle', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('retries a transient startup response while the target process remains live', async () => {
+    vi.useFakeTimers()
+    const { client, state } = createConnectionLoopHarness()
+
+    const loop = client._doConnectingLoop()
+    await vi.advanceTimersByTimeAsync(LeagueClientMain.CONNECT_TO_LC_RETRY_INTERVAL)
+    await loop
+
+    expect(client._connectToLcu).toHaveBeenCalledTimes(2)
+    expect(state.setConnectingClient).toHaveBeenLastCalledWith(null)
+    expect(client._ipc.sendEvent).toHaveBeenCalledOnce()
+  })
+
+  it('clears the retry target on an explicit disconnect', () => {
+    const { client, state } = createConnectionLoopHarness()
+    client._cleanup = vi.fn()
+
+    client.disconnect()
+
+    expect(state.connectingClient).toBeNull()
+    expect(state.setDisconnected).toHaveBeenCalledOnce()
+    expect(client._cleanup).toHaveBeenCalledOnce()
+  })
+
+  it('cannot finish a pending WebSocket connection after an explicit disconnect', async () => {
+    const { client, state, target } = createConnectionLoopHarness()
+    delete client._connectToLcu
+
+    let resolveWebSocket!: (webSocket: any) => void
+    const pendingWebSocket = new Promise<any>((resolve) => {
+      resolveWebSocket = resolve
+    })
+    const webSocket = {
+      close: vi.fn(),
+      readyState: 1,
+      send: vi.fn(),
+      on: vi.fn()
+    }
+    client._wsPromisified = vi.fn(() => pendingWebSocket)
+    client._createHttpInstance = vi.fn(async () => ({
+      httpClient: {},
+      leagueClientApi: {}
+    }))
+    client._eventBus = { emit: vi.fn() }
+    client._settingService = { _saveToStorage: vi.fn(async () => undefined) }
+
+    const connection = client._connectToLcu(target)
+    client.disconnect()
+    resolveWebSocket(webSocket)
+
+    await expect(connection).rejects.toThrow()
+    expect(state.setConnected).not.toHaveBeenCalled()
+    expect(client._createHttpInstance).not.toHaveBeenCalled()
+    expect(webSocket.close).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/shards/league-client/index.ts
+++ b/src/main/shards/league-client/index.ts
@@ -17,6 +17,7 @@ import path from 'node:path'
 import PQueue from 'p-queue'
 import WebSocket from 'ws'
 
+import { assertLocalClientRequestUrl } from '../../utils/local-client-url'
 import { AkariProtocolMain } from '../akari-protocol'
 import { AkariIpcMain } from '../ipc'
 import { LeagueClientUxMain } from '../league-client-ux'
@@ -24,6 +25,7 @@ import { AkariLogger, LoggerFactoryMain } from '../logger-factory'
 import { MobxUtilsMain } from '../mobx-utils'
 import { SettingFactoryMain } from '../setting-factory'
 import { SetterSettingService } from '../setting-factory/setter-setting-service'
+import { classifyClientCredentialChange, getClientAuthLogMetadata } from './client-auth'
 import {
   LEAGUE_CLIENT_MAIN_NAMESPACE,
   LeagueClientLcuUninitializedError,
@@ -32,8 +34,11 @@ import {
 import { LeagueClientIpcHandlers } from './ipc-handlers'
 import { LeagueClientData } from './lc-state'
 import { LeagueClientSettings, LeagueClientState } from './state'
+import { disposeUnexpectedWebSocketResponse } from './websocket-handshake'
 
 const axiosRetry = require('axios-retry').default as AxiosRetry
+
+class LeagueClientConnectionAttemptCancelledError extends Error {}
 
 export { LeagueClientLcuUninitializedError }
 export type { LeagueClientMainContext }
@@ -76,6 +81,8 @@ export class LeagueClientMain implements IAkariShardInitDispose {
   // 处理仅关闭 UX 而 LeagueClient 未关闭的情况
   private _shouldHaveOneAttempt = false
   private _manuallyDisconnected = false
+  private _connectionAttemptId = 0
+  private _isConnectionLoopRunning = false
 
   get http() {
     if (!this._httpClient) {
@@ -158,8 +165,10 @@ export class LeagueClientMain implements IAkariShardInitDispose {
       const p2 = await getPidsByName(LeagueClientMain.PROCESS_NAME)
 
       if (p1.length === 0 && p2.length === 1) {
-        const { certificate, ...rest } = lastConnectedClient
-        this._logger.info('Trying to resume connection', rest)
+        this._logger.info(
+          'Trying to resume connection',
+          getClientAuthLogMetadata(lastConnectedClient)
+        )
 
         this._shouldHaveOneAttempt = true
         this.state.setConnectingClient(lastConnectedClient)
@@ -233,6 +242,8 @@ export class LeagueClientMain implements IAkariShardInitDispose {
       throw new LeagueClientLcuUninitializedError()
     }
 
+    assertLocalClientRequestUrl(config.url)
+
     // 通过 IPC 调用的网络请求，则是不完整的可序列化信息
     try {
       const { config: c, request, ...rest } = await this._httpClient!.request(config)
@@ -263,6 +274,7 @@ export class LeagueClientMain implements IAkariShardInitDispose {
 
   disconnect() {
     this._manuallyDisconnected = true
+    this.state.setConnectingClient(null)
     this._disconnect()
   }
 
@@ -296,14 +308,8 @@ export class LeagueClientMain implements IAkariShardInitDispose {
    * 断开与 LeagueClient 的连接, 主要是 WebSocket
    */
   private _disconnect() {
-    if (this._webSocket) {
-      this._webSocket.close()
-    }
-
-    this._webSocket = null
-    this._httpClient = null
-    this._leagueClientApi = null
-
+    this._connectionAttemptId++
+    this._cleanup()
     this.state.setDisconnected()
   }
 
@@ -333,6 +339,7 @@ export class LeagueClientMain implements IAkariShardInitDispose {
         ] as const,
       async ([s, c, conn], prev) => {
         if (conn === 'connected') {
+          this._refreshConnectedClientAuth(c)
           return
         }
 
@@ -359,8 +366,7 @@ export class LeagueClientMain implements IAkariShardInitDispose {
       () => [this.state.auth, this.state.connectionState] as const,
       ([a, s]) => {
         if (a) {
-          const { certificate, ...rest } = a
-          this._logger.debug(`LCU state changed: ${s}`, rest)
+          this._logger.debug(`LCU state changed: ${s}`, getClientAuthLogMetadata(a))
         } else {
           this._logger.debug(`LCU state changed: ${s}`, a)
         }
@@ -386,43 +392,90 @@ export class LeagueClientMain implements IAkariShardInitDispose {
     )
   }
 
+  private _refreshConnectedClientAuth(clients: UxCommandLine[]) {
+    const current = this.state.auth
+    if (!current) {
+      return
+    }
+
+    const refreshed = clients.find((client) => client.pid === current.pid)
+    if (!refreshed) {
+      return
+    }
+
+    const credentialChange = classifyClientCredentialChange(current, refreshed)
+    if (credentialChange === 'league-client') {
+      this._logger.info(
+        'League Client credentials changed; reconnecting',
+        getClientAuthLogMetadata(refreshed)
+      )
+      this._disconnect()
+      this.state.setConnectingClient(refreshed)
+      return
+    }
+
+    if (credentialChange === 'riot-client') {
+      this._logger.info(
+        'Riot Client credentials changed; refreshing local connection',
+        getClientAuthLogMetadata(refreshed)
+      )
+      this.state.setConnected(refreshed)
+      this._settingService._saveToStorage('lastConnectedClient', refreshed).catch(() => {})
+    }
+  }
+
   private async _doConnectingLoop() {
-    while (true) {
-      // 连接途中，目标丢失，停止连接
-      if (!this.state.connectingClient) {
-        break
-      }
+    if (this._isConnectionLoopRunning) {
+      return
+    }
 
-      // 目标连接对象已不在当前启动列表中，停止连接
-      if (
-        !this._shouldHaveOneAttempt &&
-        !this._leagueClientUx.state.launchedClients.find(
-          (c) => c.pid === this.state.connectingClient?.pid
-        )
-      ) {
-        this.state.setConnectingClient(null)
-        break
-      }
-
-      try {
-        await this._connectToLcu(this.state.connectingClient)
-        this.state.setConnectingClient(null) // finished connecting!
-        break
-      } catch (error) {
-        if ((error as any).code !== 'ECONNREFUSED') {
-          this._ipc.sendEvent(LeagueClientMain.id, 'error-connecting', (error as any)?.message)
-          this._logger.warn(`Error connecting to LC`, error)
+    this._isConnectionLoopRunning = true
+    try {
+      while (true) {
+        // 连接途中，目标丢失，停止连接
+        if (!this.state.connectingClient) {
           break
         }
-      }
 
-      if (this._shouldHaveOneAttempt) {
-        this._shouldHaveOneAttempt = false
-        this.state.setConnectingClient(null)
-        break
-      }
+        // 目标连接对象已不在当前启动列表中，停止连接
+        if (
+          !this._shouldHaveOneAttempt &&
+          !this._leagueClientUx.state.launchedClients.find(
+            (c) => c.pid === this.state.connectingClient?.pid
+          )
+        ) {
+          this.state.setConnectingClient(null)
+          break
+        }
 
-      await sleep(LeagueClientMain.CONNECT_TO_LC_RETRY_INTERVAL)
+        try {
+          await this._connectToLcu(this.state.connectingClient)
+          this.state.setConnectingClient(null) // finished connecting!
+          break
+        } catch (error) {
+          if (error instanceof LeagueClientConnectionAttemptCancelledError) {
+            continue
+          }
+
+          if ((error as any).code !== 'ECONNREFUSED') {
+            this._ipc.sendEvent(LeagueClientMain.id, 'error-connecting', (error as any)?.message)
+            this._logger.warn(`Error connecting to LC`, error)
+          }
+        }
+
+        if (this._shouldHaveOneAttempt) {
+          this._shouldHaveOneAttempt = false
+          this.state.setConnectingClient(null)
+          break
+        }
+
+        await sleep(LeagueClientMain.CONNECT_TO_LC_RETRY_INTERVAL)
+      }
+    } finally {
+      this._isConnectionLoopRunning = false
+      if (this.state.connectingClient) {
+        void this._doConnectingLoop()
+      }
     }
   }
 
@@ -433,38 +486,85 @@ export class LeagueClientMain implements IAkariShardInitDispose {
   ): Promise<WebSocket> {
     return new Promise<WebSocket>((resolve, reject) => {
       const ws = new WebSocket(url, options)
+      let settled = false
+
+      const rejectOnce = (error: Error) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timer)
+        reject(error)
+      }
 
       const timer = setTimeout(() => {
-        ws.close()
-        reject(new Error(`WebSocket connection timed out after ${timeout}ms`))
+        rejectOnce(new Error(`WebSocket connection timed out after ${timeout}ms`))
+        ws.terminate()
       }, timeout)
 
-      ws.on('open', () => {
+      ws.once('open', () => {
+        if (settled) return
+        settled = true
         clearTimeout(timer)
         resolve(ws)
       })
 
-      ws.on('unexpected-response', (_req, res) => {
-        clearTimeout(timer)
-        reject(new Error(`WebSocket unexpected response: ${res.statusCode} ${res.statusMessage}`))
+      ws.once('unexpected-response', (_req, res) => {
+        rejectOnce(
+          new Error(`WebSocket unexpected response: ${res.statusCode} ${res.statusMessage}`)
+        )
+        disposeUnexpectedWebSocketResponse(ws, res)
       })
 
-      ws.on('close', () => clearTimeout(timer))
+      ws.once('close', () => {
+        rejectOnce(new Error('WebSocket closed before the connection was established'))
+      })
 
       ws.on('error', (err) => {
-        clearTimeout(timer)
-        reject(err)
+        rejectOnce(err)
       })
     })
   }
 
   private _cleanup() {
-    if (this._webSocket && this._webSocket.readyState !== WebSocket.CLOSED) {
-      this._webSocket.close()
-      this._webSocket = null
+    const webSocket = this._webSocket
+    this._webSocket = null
+
+    if (webSocket && webSocket.readyState !== WebSocket.CLOSED) {
+      webSocket.close()
     }
     this._httpClient = null
     this._leagueClientApi = null
+  }
+
+  private _assertConnectionAttemptCurrent(
+    attemptId: number,
+    commandLine: UxCommandLine,
+    webSocket?: WebSocket
+  ) {
+    const target = this.state.connectingClient
+    const isCurrent =
+      attemptId === this._connectionAttemptId &&
+      target?.pid === commandLine.pid &&
+      classifyClientCredentialChange(commandLine, target) === 'none'
+
+    if (isCurrent) {
+      return
+    }
+
+    if (webSocket) {
+      if (this._webSocket === webSocket) {
+        this._webSocket = null
+      }
+      if (webSocket.readyState !== WebSocket.CLOSING && webSocket.readyState !== WebSocket.CLOSED) {
+        webSocket.close()
+      }
+    }
+
+    if (attemptId === this._connectionAttemptId) {
+      this._connectionAttemptId++
+      this.state.setDisconnected()
+    }
+
+    throw new LeagueClientConnectionAttemptCancelledError()
   }
 
   /**
@@ -475,65 +575,70 @@ export class LeagueClientMain implements IAkariShardInitDispose {
       return
     }
 
-    const { certificate, ...rest } = cmd
+    this._logger.info('Target client', getClientAuthLogMetadata(cmd))
 
-    this._logger.info('Target client', rest)
-
+    const attemptId = ++this._connectionAttemptId
     this.state.setConnecting()
-
-    const initWs = async () => {
-      try {
-        // in case of connection is not closed properly
-        if (this._webSocket) {
-          this._webSocket.close()
-          this._webSocket = null
-        }
-
-        this._webSocket = await this._wsPromisified(
-          `wss://riot:${cmd.authToken}@127.0.0.1:${cmd.port}`,
-          {
-            headers: {
-              Authorization: `Basic ${Buffer.from(`riot:${cmd.authToken}`).toString('base64')}`
-            },
-            rejectUnauthorized: false
-          }
-        )
-
-        for (const endpoint of SUBSCRIBED_LCU_ENDPOINTS) {
-          this._webSocket.send(JSON.stringify([5, endpoint]))
-        }
-
-        this._webSocket.on('message', (msg) => {
-          try {
-            const data = JSON.parse(msg.toString())
-            this._eventBus.emit(data[2].uri, data[2])
-          } catch {}
-        })
-
-        this._webSocket.on('close', () => {
-          this.state.setDisconnected()
-          this._cleanup()
-        })
-      } catch (error) {
-        throw error
-      }
-    }
+    let webSocket: WebSocket | undefined
 
     try {
-      await initWs()
-      await this._initHttpInstance(cmd)
+      this._cleanup()
+      webSocket = await this._wsPromisified(`wss://riot:${cmd.authToken}@127.0.0.1:${cmd.port}`, {
+        headers: {
+          Authorization: `Basic ${Buffer.from(`riot:${cmd.authToken}`).toString('base64')}`
+        },
+        rejectUnauthorized: false
+      })
+      this._assertConnectionAttemptCurrent(attemptId, cmd, webSocket)
+      this._webSocket = webSocket
+
+      for (const endpoint of SUBSCRIBED_LCU_ENDPOINTS) {
+        webSocket.send(JSON.stringify([5, endpoint]))
+      }
+
+      webSocket.on('message', (msg) => {
+        try {
+          const data = JSON.parse(msg.toString())
+          this._eventBus.emit(data[2].uri, data[2])
+        } catch {}
+      })
+
+      webSocket.on('close', () => {
+        if (this._webSocket !== webSocket) {
+          return
+        }
+
+        this._disconnect()
+      })
+
+      const { httpClient, leagueClientApi } = await this._createHttpInstance(cmd)
+      this._assertConnectionAttemptCurrent(attemptId, cmd, webSocket)
+      this._httpClient = httpClient
+      this._leagueClientApi = leagueClientApi
       this.state.setConnected(cmd)
       this._settingService._saveToStorage('lastConnectedClient', cmd).catch(() => {})
     } catch (error) {
-      this.state.setDisconnected()
-      this._cleanup()
+      if (error instanceof LeagueClientConnectionAttemptCancelledError) {
+        throw error
+      }
+
+      if (attemptId === this._connectionAttemptId) {
+        this._disconnect()
+      } else if (
+        webSocket &&
+        webSocket.readyState !== WebSocket.CLOSING &&
+        webSocket.readyState !== WebSocket.CLOSED
+      ) {
+        webSocket.close()
+      }
       throw error
     }
   }
 
-  private async _initHttpInstance(auth: UxCommandLine) {
-    this._httpClient = axios.create({
+  private async _createHttpInstance(auth: UxCommandLine) {
+    const httpClient = axios.create({
       baseURL: `https://127.0.0.1:${auth.port}`,
+      allowAbsoluteUrls: false,
       headers: {
         Authorization: `Basic ${Buffer.from(`riot:${auth.authToken}`).toString('base64')}`
       },
@@ -545,16 +650,17 @@ export class LeagueClientMain implements IAkariShardInitDispose {
       proxy: false
     })
 
-    axiosRetry(this._httpClient, { retries: 2 })
+    axiosRetry(httpClient, { retries: 2 })
 
     try {
-      await this._httpClient.get(LeagueClientMain.HTTP_PING_URL)
-      this._leagueClientApi = new LeagueClientHttpApiAxiosHelper(this._httpClient)
-    } catch (error) {
-      if (isAxiosError(error) && (!error.response || (error.status && error.status >= 500))) {
-        this._logger.warn(`Failed to execute PING operation`, error)
-        throw error
+      await httpClient.get(LeagueClientMain.HTTP_PING_URL)
+      return {
+        httpClient,
+        leagueClientApi: new LeagueClientHttpApiAxiosHelper(httpClient)
       }
+    } catch (error) {
+      this._logger.warn(`Failed to execute PING operation`, error)
+      throw error
     }
   }
 
@@ -562,6 +668,8 @@ export class LeagueClientMain implements IAkariShardInitDispose {
     if (!this._httpClient) {
       throw new LeagueClientLcuUninitializedError()
     }
+
+    assertLocalClientRequestUrl(config.url)
 
     if (config.url && config.url.startsWith('lol-game-data/assets')) {
       return this._limitedRequest(config, this._assetLimiter)
@@ -635,6 +743,7 @@ export class LeagueClientMain implements IAkariShardInitDispose {
   async peekClient(auth: UxCommandLine) {
     const c = axios.create({
       baseURL: `https://127.0.0.1:${auth.port}`,
+      allowAbsoluteUrls: false,
       headers: {
         Authorization: `Basic ${Buffer.from(`riot:${auth.authToken}`).toString('base64')}`
       },
@@ -670,7 +779,7 @@ export class LeagueClientMain implements IAkariShardInitDispose {
    * 不知道现在是否需要
    */
   async fixWindowMethodA(config?: { baseHeight: number; baseWidth: number }) {
-    if (!NATIVE_SUPPORT.adjustLeagueClientWindowSize) {
+    if (!NATIVE_SUPPORT.adjustLeagueClientWindowSize.available) {
       return
     }
 

--- a/src/main/shards/league-client/ipc-handlers.ts
+++ b/src/main/shards/league-client/ipc-handlers.ts
@@ -1,6 +1,7 @@
 import type { UxCommandLine } from '@shared/shards/league-client-ux'
 import type { AxiosRequestConfig } from 'axios'
 
+import { assertLocalClientRequestUrl } from '../../utils/local-client-url'
 import type { LeagueClientMainContext } from './context'
 
 export class LeagueClientIpcHandlers {
@@ -10,6 +11,7 @@ export class LeagueClientIpcHandlers {
     const { ipc, leagueClient, namespace } = this.context
 
     ipc.onCall(namespace, 'http-request', async (_, config: AxiosRequestConfig) => {
+      assertLocalClientRequestUrl(config.url)
       return leagueClient.requestForRenderer(config)
     })
 

--- a/src/main/shards/league-client/websocket-handshake.test.ts
+++ b/src/main/shards/league-client/websocket-handshake.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest'
+import WebSocket from 'ws'
+
+import { disposeUnexpectedWebSocketResponse } from './websocket-handshake'
+
+describe('disposeUnexpectedWebSocketResponse', () => {
+  it('drains the HTTP response and terminates a rejected CONNECTING socket', () => {
+    const response = { destroy: vi.fn(), resume: vi.fn() }
+    const webSocket = { readyState: WebSocket.CONNECTING, terminate: vi.fn() }
+
+    disposeUnexpectedWebSocketResponse(webSocket, response)
+
+    expect(response.resume).toHaveBeenCalledOnce()
+    expect(response.destroy).toHaveBeenCalledOnce()
+    expect(webSocket.terminate).toHaveBeenCalledOnce()
+  })
+
+  it('does not terminate a socket that has already left CONNECTING state', () => {
+    const response = { destroy: vi.fn(), resume: vi.fn() }
+    const webSocket = { readyState: WebSocket.CLOSED, terminate: vi.fn() }
+
+    disposeUnexpectedWebSocketResponse(webSocket, response)
+
+    expect(response.resume).toHaveBeenCalledOnce()
+    expect(response.destroy).toHaveBeenCalledOnce()
+    expect(webSocket.terminate).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/shards/league-client/websocket-handshake.ts
+++ b/src/main/shards/league-client/websocket-handshake.ts
@@ -1,0 +1,19 @@
+import type { IncomingMessage } from 'node:http'
+import WebSocket from 'ws'
+
+/**
+ * `ws` delegates ownership of an unexpected HTTP response to applications that subscribe to the
+ * event. Consume and destroy it before aborting the still-CONNECTING socket so retries cannot leak
+ * response sockets.
+ */
+export function disposeUnexpectedWebSocketResponse(
+  webSocket: Pick<WebSocket, 'readyState' | 'terminate'>,
+  response: Pick<IncomingMessage, 'destroy' | 'resume'>
+) {
+  response.resume()
+  response.destroy()
+
+  if (webSocket.readyState === WebSocket.CONNECTING) {
+    webSocket.terminate()
+  }
+}

--- a/src/main/shards/logger-factory/log-message-formatter.test.ts
+++ b/src/main/shards/logger-factory/log-message-formatter.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { LogMessageFormatter } from './log-message-formatter'
+
+const SYNTHETIC_LCU_TOKEN = 'synthetic-lcu-secret_DO_NOT_USE'
+const SYNTHETIC_RIOT_TOKEN = 'synthetic-riot-secret_DO_NOT_USE'
+
+describe('LogMessageFormatter credential redaction', () => {
+  it('redacts credentials in strings and nested structured values', () => {
+    const message = new LogMessageFormatter().objectsToString(
+      `LeagueClientUx --remoting-auth-token=${SYNTHETIC_LCU_TOKEN}`,
+      {
+        nested: {
+          riotClientAuthToken: SYNTHETIC_RIOT_TOKEN,
+          authorization: `Basic ${SYNTHETIC_RIOT_TOKEN}`
+        },
+        port: 54321
+      }
+    )
+
+    expect(message).not.toContain(SYNTHETIC_LCU_TOKEN)
+    expect(message).not.toContain(SYNTHETIC_RIOT_TOKEN)
+    expect(message).toContain('--remoting-auth-token=<redacted>')
+    expect(message).toContain('"riotClientAuthToken": "<redacted>"')
+    expect(message).toContain('"authorization": "<redacted>"')
+    expect(message).toContain('"port": 54321')
+  })
+})

--- a/src/main/shards/logger-factory/log-message-formatter.ts
+++ b/src/main/shards/logger-factory/log-message-formatter.ts
@@ -1,11 +1,15 @@
 import { formatError } from '@shared/utils/errors'
+import {
+  createSecretRedactingJsonReplacer,
+  redactSecretsInString
+} from '@shared/utils/redact-secrets'
 
 export class LogMessageFormatter {
   objectsToString(...args: any[]) {
     return args
       .map((arg) => {
         if (arg instanceof Error || this._isLikelyErrorObject(arg)) {
-          return formatError(arg)
+          return redactSecretsInString(formatError(arg))
         }
 
         if (typeof arg === 'undefined') {
@@ -13,18 +17,18 @@ export class LogMessageFormatter {
         }
 
         if (typeof arg === 'function') {
-          return arg.toString()
+          return redactSecretsInString(arg.toString())
         }
 
         if (typeof arg === 'object') {
           try {
-            return JSON.stringify(arg, null, 2)
+            return JSON.stringify(arg, createSecretRedactingJsonReplacer(), 2)
           } catch {
             return `[Cannot stringify: ${arg}]`
           }
         }
 
-        return arg
+        return typeof arg === 'string' ? redactSecretsInString(arg) : arg
       })
       .join(' ')
   }

--- a/src/main/shards/remote-config/builtin.ts
+++ b/src/main/shards/remote-config/builtin.ts
@@ -81,11 +81,13 @@ export const BUILTIN_SGP_LEAGUE_SERVERS_CONFIG: LeagueServersConfig = {
     },
     EUW: {
       matchHistory: 'https://euc1-red.pp.sgp.pvp.net',
-      common: 'https://euw-red.lol.sgp.pvp.net'
+      common: 'https://euw-red.lol.sgp.pvp.net',
+      regionPathParam: 'EUW1'
     },
     JP: {
       matchHistory: 'https://apne1-red.pp.sgp.pvp.net',
-      common: 'https://jp-red.lol.sgp.pvp.net'
+      common: 'https://jp-red.lol.sgp.pvp.net',
+      regionPathParam: 'JP1'
     },
     RU: {
       matchHistory: 'https://euc1-red.pp.sgp.pvp.net',

--- a/src/main/shards/riot-client/index.ts
+++ b/src/main/shards/riot-client/index.ts
@@ -1,9 +1,9 @@
 import { IAkariShardInitDispose, Shard } from '@shared/akari-shard'
 import { RiotClientHttpApiAxiosHelper } from '@shared/http-api-axios-helper/riot-client'
-import { UxCommandLine } from '@shared/shards/league-client-ux'
 import axios, { AxiosInstance, AxiosRequestConfig, isAxiosError } from 'axios'
 import https from 'https'
 
+import { assertLocalClientRequestUrl } from '../../utils/local-client-url'
 import { AkariProtocolMain } from '../akari-protocol'
 import { AkariIpcMain } from '../ipc'
 import { LeagueClientMain } from '../league-client'
@@ -16,6 +16,12 @@ import {
   RiotClientRcuUninitializedError
 } from './context'
 import { RiotClientIpcHandlers } from './ipc-handlers'
+import {
+  type RiotClientProcessAuth,
+  RiotClientProcessAuthReader,
+  shouldReadRiotClientProcessAuth
+} from './process-auth'
+import { RiotClientProcessAuthController } from './process-auth-controller'
 import { RiotClientProtocolController } from './protocol-controller'
 
 export { RiotClientRcuUninitializedError }
@@ -28,11 +34,13 @@ export class RiotClientMain implements IAkariShardInitDispose {
   static id = RIOT_CLIENT_MAIN_NAMESPACE
 
   static REQUEST_TIMEOUT_MS = RIOT_CLIENT_REQUEST_TIMEOUT_MS
+  static PROCESS_AUTH_POLL_INTERVAL = 5000
 
   private readonly _logger: AkariLogger
   private readonly _context: RiotClientMainContext
   private readonly _ipcHandlers: RiotClientIpcHandlers
   private readonly _protocolController: RiotClientProtocolController
+  private readonly _processAuthController: RiotClientProcessAuthController | null
 
   private _riotClientApi: RiotClientHttpApiAxiosHelper | null = null
 
@@ -61,6 +69,20 @@ export class RiotClientMain implements IAkariShardInitDispose {
     }
     this._ipcHandlers = new RiotClientIpcHandlers(this._context)
     this._protocolController = new RiotClientProtocolController(this._context)
+    this._processAuthController = shouldReadRiotClientProcessAuth()
+      ? new RiotClientProcessAuthController(
+          new RiotClientProcessAuthReader(),
+          (auth) => {
+            if (auth) {
+              this._initHttpInstance(auth)
+            } else {
+              this._clearHttpInstance()
+            }
+          },
+          this._logger,
+          RiotClientMain.PROCESS_AUTH_POLL_INTERVAL
+        )
+      : null
 
     this._protocolController.register()
   }
@@ -74,6 +96,8 @@ export class RiotClientMain implements IAkariShardInitDispose {
   }
 
   async requestForRenderer(config: AxiosRequestConfig) {
+    assertLocalClientRequestUrl(config.url)
+
     try {
       const { config: c, request, ...rest } = await this._httpClient!.request(config)
 
@@ -104,37 +128,51 @@ export class RiotClientMain implements IAkariShardInitDispose {
       throw new Error('RC Uninitialized')
     }
 
+    assertLocalClientRequestUrl(config.url)
     return this._httpClient.request<T>(config)
   }
 
   async onInit() {
     this._ipcHandlers.register()
 
-    this._mobxUtils.reaction(
-      () => this._leagueClient.state.auth,
-      async (auth) => {
-        if (auth) {
-          this._initHttpInstance(auth)
-        } else {
-          this._httpClient = null
-          this._riotClientApi = null
-        }
-      },
-      { fireImmediately: true }
-    )
+    if (this._processAuthController) {
+      await this._processAuthController.start()
+    } else {
+      this._mobxUtils.reaction(
+        () => this._leagueClient.state.auth,
+        async (auth) => {
+          if (auth?.riotClientPort && auth.riotClientAuthToken) {
+            this._initHttpInstance({
+              authToken: auth.riotClientAuthToken,
+              pid: auth.pid,
+              port: auth.riotClientPort
+            })
+          } else {
+            this._clearHttpInstance()
+          }
+        },
+        { fireImmediately: true }
+      )
+    }
   }
 
   async onDispose() {
-    this._httpClient = null
-    this._riotClientApi = null
+    this._processAuthController?.stop()
+    this._clearHttpInstance()
     this._protocol.unregisterDomain('riot-client')
   }
 
-  private _initHttpInstance(auth: UxCommandLine) {
+  private _clearHttpInstance() {
+    this._httpClient = null
+    this._riotClientApi = null
+  }
+
+  private _initHttpInstance(auth: RiotClientProcessAuth) {
     this._httpClient = axios.create({
-      baseURL: `https://127.0.0.1:${auth.riotClientPort}`,
+      baseURL: `https://127.0.0.1:${auth.port}`,
+      allowAbsoluteUrls: false,
       headers: {
-        Authorization: `Basic ${Buffer.from(`riot:${auth.riotClientAuthToken}`).toString('base64')}`
+        Authorization: `Basic ${Buffer.from(`riot:${auth.authToken}`).toString('base64')}`
       },
       httpsAgent: new https.Agent({
         rejectUnauthorized: false,

--- a/src/main/shards/riot-client/ipc-handlers.ts
+++ b/src/main/shards/riot-client/ipc-handlers.ts
@@ -1,5 +1,6 @@
 import type { AxiosRequestConfig } from 'axios'
 
+import { assertLocalClientRequestUrl } from '../../utils/local-client-url'
 import type { RiotClientMainContext } from './context'
 
 export class RiotClientIpcHandlers {
@@ -9,6 +10,7 @@ export class RiotClientIpcHandlers {
     const { ipc, namespace, riotClient } = this.context
 
     ipc.onCall(namespace, 'http-request', async (_, config: AxiosRequestConfig) => {
+      assertLocalClientRequestUrl(config.url)
       return riotClient.requestForRenderer(config)
     })
   }

--- a/src/main/shards/riot-client/process-auth-controller.ts
+++ b/src/main/shards/riot-client/process-auth-controller.ts
@@ -1,0 +1,90 @@
+import type { AkariLogger } from '../logger-factory'
+import type { RiotClientProcessAuth, RiotClientProcessAuthReaderLike } from './process-auth'
+
+export class RiotClientProcessAuthController {
+  private _activeAuth: RiotClientProcessAuth | null = null
+  private _pollInFlight: Promise<void> | null = null
+  private _pollTimer: NodeJS.Timeout | null = null
+  private _running = false
+
+  constructor(
+    private readonly _reader: RiotClientProcessAuthReaderLike,
+    private readonly _onAuthChanged: (auth: RiotClientProcessAuth | null) => void,
+    private readonly _logger: Pick<AkariLogger, 'debug' | 'info' | 'warn'>,
+    private readonly _pollInterval: number
+  ) {}
+
+  async start() {
+    if (this._running) return
+    this._running = true
+    await this.updateNow()
+  }
+
+  stop() {
+    this._running = false
+    if (this._pollTimer) {
+      clearTimeout(this._pollTimer)
+      this._pollTimer = null
+    }
+  }
+
+  async updateNow() {
+    if (!this._running) return
+    if (this._pollInFlight) return this._pollInFlight
+
+    this._pollInFlight = this._poll()
+    try {
+      await this._pollInFlight
+    } finally {
+      this._pollInFlight = null
+      this._scheduleNextPoll()
+    }
+  }
+
+  private async _poll() {
+    try {
+      const result = await this._reader.read()
+      if (!this._running) return
+
+      if (result.status === 'unreadable') {
+        this._logger.debug('Riot Client is running but its local API credentials are unavailable')
+        return
+      }
+
+      if (result.status === 'not-running') {
+        if (this._activeAuth) {
+          this._activeAuth = null
+          this._onAuthChanged(null)
+        }
+        return
+      }
+
+      if (
+        this._activeAuth?.pid === result.auth.pid &&
+        this._activeAuth.port === result.auth.port &&
+        this._activeAuth.authToken === result.auth.authToken
+      ) {
+        return
+      }
+
+      this._activeAuth = result.auth
+      this._logger.info('Riot Client local API credentials discovered', {
+        pid: result.auth.pid,
+        port: result.auth.port
+      })
+      this._onAuthChanged(result.auth)
+    } catch (error) {
+      this._logger.warn('Failed to inspect Riot Client process', error)
+    }
+  }
+
+  private _scheduleNextPoll() {
+    if (!this._running) return
+    if (this._pollTimer) clearTimeout(this._pollTimer)
+
+    this._pollTimer = setTimeout(() => {
+      this._pollTimer = null
+      void this.updateNow()
+    }, this._pollInterval)
+  }
+}

--- a/src/main/shards/riot-client/process-auth.test.ts
+++ b/src/main/shards/riot-client/process-auth.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  RiotClientProcessAuthReader,
+  getRiotClientProcessName,
+  parseRiotClientProcessCommandLine,
+  shouldReadRiotClientProcessAuth
+} from './process-auth'
+import { RiotClientProcessAuthController } from './process-auth-controller'
+
+const SYNTHETIC_TOKEN_1 = 'synthetic-riot-token-one_DO_NOT_USE'
+const SYNTHETIC_TOKEN_2 = 'synthetic-riot-token-two_DO_NOT_USE'
+
+describe('Riot Client process authentication', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('parses safe argument-array process output with spaces before Riot credentials', () => {
+    const commandLine =
+      '/Applications/Riot Client.app/Contents/MacOS/RiotClientServices ' +
+      `--app-port=51234 --remoting-auth-token=${SYNTHETIC_TOKEN_1} ` +
+      '--app-root=/Applications/Riot Client.app'
+
+    expect(parseRiotClientProcessCommandLine(commandLine, 4242)).toEqual({
+      authToken: SYNTHETIC_TOKEN_1,
+      pid: 4242,
+      port: 51234
+    })
+  })
+
+  it('rejects missing credentials and ports outside the TCP range', () => {
+    expect(
+      parseRiotClientProcessCommandLine(
+        `RiotClientServices --app-port=65536 --remoting-auth-token=${SYNTHETIC_TOKEN_1}`,
+        1
+      )
+    ).toBeNull()
+    expect(parseRiotClientProcessCommandLine('RiotClientServices --app-port=51234', 1)).toBeNull()
+  })
+
+  it('uses the process reader only on Darwin without changing Windows process naming', () => {
+    expect(shouldReadRiotClientProcessAuth('darwin')).toBe(true)
+    expect(shouldReadRiotClientProcessAuth('win32')).toBe(false)
+    expect(getRiotClientProcessName('darwin')).toBe('RiotClientServices')
+    expect(getRiotClientProcessName('win32')).toBe('RiotClientServices.exe')
+  })
+
+  it('reads Riot credentials from LeagueClientUx when RiotClientServices has no API flags', async () => {
+    const listProcesses = vi.fn(async () => [
+      {
+        executablePath:
+          '/Users/Shared/Riot Games/Riot Client.app/Contents/MacOS/RiotClientServices',
+        name: 'RiotClientServices',
+        pid: 100
+      },
+      {
+        executablePath: '/Applications/League of Legends.app/Contents/LoL/LeagueClientUx',
+        name: 'LeagueClientUx',
+        pid: 200
+      }
+    ])
+    const getCommandLine = vi.fn(async (pid: number) =>
+      pid === 100
+        ? '/Users/Shared/Riot Games/Riot Client.app/Contents/MacOS/RiotClientServices'
+        : '/Applications/League of Legends.app/Contents/LoL/LeagueClientUx ' +
+          `--riotclient-app-port=51234 --riotclient-auth-token=${SYNTHETIC_TOKEN_1}`
+    )
+
+    await expect(
+      new RiotClientProcessAuthReader(listProcesses, getCommandLine).read()
+    ).resolves.toEqual({
+      status: 'found',
+      auth: {
+        authToken: SYNTHETIC_TOKEN_1,
+        pid: 100,
+        port: 51234
+      }
+    })
+
+    expect(getCommandLine).toHaveBeenNthCalledWith(1, 100)
+    expect(getCommandLine).toHaveBeenNthCalledWith(2, 200)
+  })
+
+  it('publishes rotation and process exit without clearing on a transient unreadable result', async () => {
+    const results = [
+      {
+        status: 'found' as const,
+        auth: { authToken: SYNTHETIC_TOKEN_1, pid: 100, port: 51001 }
+      },
+      { status: 'unreadable' as const },
+      {
+        status: 'found' as const,
+        auth: { authToken: SYNTHETIC_TOKEN_2, pid: 200, port: 51002 }
+      },
+      { status: 'not-running' as const }
+    ]
+    const reader = { read: vi.fn(async () => results.shift()!) }
+    const onAuthChanged = vi.fn()
+    const controller = new RiotClientProcessAuthController(
+      reader,
+      onAuthChanged,
+      { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
+      60_000
+    )
+
+    await controller.start()
+    await controller.updateNow()
+    await controller.updateNow()
+    await controller.updateNow()
+    controller.stop()
+
+    expect(onAuthChanged).toHaveBeenNthCalledWith(1, {
+      authToken: SYNTHETIC_TOKEN_1,
+      pid: 100,
+      port: 51001
+    })
+    expect(onAuthChanged).toHaveBeenNthCalledWith(2, {
+      authToken: SYNTHETIC_TOKEN_2,
+      pid: 200,
+      port: 51002
+    })
+    expect(onAuthChanged).toHaveBeenNthCalledWith(3, null)
+  })
+})

--- a/src/main/shards/riot-client/process-auth.ts
+++ b/src/main/shards/riot-client/process-auth.ts
@@ -1,0 +1,106 @@
+import { getProcessCommandLineOption } from '@main/native/process-command-line'
+import {
+  findPidsByNamePosix,
+  getCommandLinePosix,
+  listProcessesPosix
+} from '@main/native/process-utils-darwin'
+
+export interface RiotClientProcessAuth {
+  authToken: string
+  pid: number
+  port: number
+}
+
+export type RiotClientProcessAuthReadResult =
+  | { status: 'found'; auth: RiotClientProcessAuth }
+  | { status: 'not-running' }
+  | { status: 'unreadable' }
+
+export interface RiotClientProcessAuthReaderLike {
+  read(): Promise<RiotClientProcessAuthReadResult>
+}
+
+type ListProcesses = typeof listProcessesPosix
+type GetCommandLine = typeof getCommandLinePosix
+
+export function shouldReadRiotClientProcessAuth(platform: NodeJS.Platform = process.platform) {
+  return platform === 'darwin'
+}
+
+export function getRiotClientProcessName(platform: NodeJS.Platform = process.platform) {
+  return platform === 'win32' ? 'RiotClientServices.exe' : 'RiotClientServices'
+}
+
+export function parseRiotClientProcessCommandLine(
+  commandLine: string,
+  pid: number
+): RiotClientProcessAuth | null {
+  if (!Number.isSafeInteger(pid) || pid <= 0) {
+    return null
+  }
+
+  const portValue = getProcessCommandLineOption(commandLine, ['app-port', 'riotclient-app-port'])
+  const authToken = getProcessCommandLineOption(commandLine, [
+    'remoting-auth-token',
+    'riotclient-auth-token'
+  ])
+
+  if (!portValue || !/^\d+$/.test(portValue) || !authToken) {
+    return null
+  }
+
+  const port = Number(portValue)
+  if (!Number.isSafeInteger(port) || port <= 0 || port > 65_535) {
+    return null
+  }
+
+  return { authToken, pid, port }
+}
+
+export class RiotClientProcessAuthReader implements RiotClientProcessAuthReaderLike {
+  constructor(
+    private readonly _listProcesses: ListProcesses = listProcessesPosix,
+    private readonly _getCommandLine: GetCommandLine = getCommandLinePosix
+  ) {}
+
+  async read(): Promise<RiotClientProcessAuthReadResult> {
+    // Unlike the generic PID helper, keep a process-list execution failure distinguishable from
+    // a confirmed empty list. The controller will retain working credentials on the former.
+    const processes = await this._listProcesses()
+    const pids = findPidsByNamePosix(processes, getRiotClientProcessName())
+    if (!pids.length) {
+      return { status: 'not-running' }
+    }
+
+    for (const pid of pids) {
+      try {
+        const auth = parseRiotClientProcessCommandLine(await this._getCommandLine(pid), pid)
+        if (auth) {
+          return { status: 'found', auth }
+        }
+      } catch {
+        // Processes can exit between the list and command-line reads; try the next candidate.
+      }
+    }
+
+    // Current macOS Riot builds can launch RiotClientServices without API arguments. While League
+    // is running, LeagueClientUx carries the same Riot port/token pair. Keep the confirmed Riot PID
+    // as the identity used for rotation, and use the UX process only as the credential source.
+    const leagueClientUxPids = findPidsByNamePosix(processes, 'LeagueClientUx')
+    for (const leagueClientUxPid of leagueClientUxPids) {
+      try {
+        const auth = parseRiotClientProcessCommandLine(
+          await this._getCommandLine(leagueClientUxPid),
+          pids[0]
+        )
+        if (auth) {
+          return { status: 'found', auth }
+        }
+      } catch {
+        // As above, a process can exit between list and command-line inspection.
+      }
+    }
+
+    return { status: 'unreadable' }
+  }
+}

--- a/src/main/shards/sgp/http-client-controller.test.ts
+++ b/src/main/shards/sgp/http-client-controller.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveSgpRegionPathParam } from './http-client-controller'
+
+describe('resolveSgpRegionPathParam', () => {
+  it('prefers an explicit remote configuration value', () => {
+    expect(resolveSgpRegionPathParam('PBE', 'PBE1')).toBe('PBE1')
+  })
+
+  it('uses the active Riot platform ID for the current server', () => {
+    expect(
+      resolveSgpRegionPathParam('EUW', undefined, {
+        sgpServerId: 'EUW',
+        rsoPlatformId: 'euw1'
+      })
+    ).toBe('EUW1')
+  })
+
+  it('uses known platform IDs for cross-region requests', () => {
+    expect(resolveSgpRegionPathParam('EUW')).toBe('EUW1')
+    expect(resolveSgpRegionPathParam('JP')).toBe('JP1')
+  })
+
+  it('preserves ordinary platform IDs and extracts Tencent sub IDs', () => {
+    expect(resolveSgpRegionPathParam('NA1')).toBe('NA1')
+    expect(resolveSgpRegionPathParam('TENCENT_HN10')).toBe('HN10')
+  })
+})

--- a/src/main/shards/sgp/http-client-controller.ts
+++ b/src/main/shards/sgp/http-client-controller.ts
@@ -9,6 +9,31 @@ import { isAxiosError } from 'axios'
 import type { SgpMainContext } from './context'
 import { isNodeReadableStream, readNodeStreamToBuffer } from './node-stream-reader'
 
+const SGP_REGION_PATH_PARAM_FALLBACKS: Readonly<Record<string, string>> = {
+  EUW: 'EUW1',
+  JP: 'JP1'
+}
+
+export function resolveSgpRegionPathParam(
+  sgpServerId: string,
+  configuredRegionPathParam?: string,
+  currentServer?: { sgpServerId: string; rsoPlatformId: string }
+) {
+  if (configuredRegionPathParam) {
+    return configuredRegionPathParam
+  }
+
+  if (currentServer?.sgpServerId === sgpServerId && currentServer.rsoPlatformId.trim().length > 0) {
+    return currentServer.rsoPlatformId.toUpperCase()
+  }
+
+  if (sgpServerId.startsWith('TENCENT_')) {
+    return sgpServerId.slice('TENCENT_'.length)
+  }
+
+  return SGP_REGION_PATH_PARAM_FALLBACKS[sgpServerId] ?? sgpServerId
+}
+
 export class SgpHttpClientController {
   constructor(private readonly context: SgpMainContext) {}
 
@@ -62,9 +87,19 @@ export class SgpHttpClientController {
       }
 
       if (config.url) {
+        const availability = state.availability
         config.url = config.url.replace(
           URL_PLACEHOLDER_SUB_ID,
-          serverConfig.regionPathParam ?? this._getSubId(preferredSgpServerId)
+          resolveSgpRegionPathParam(
+            preferredSgpServerId,
+            serverConfig.regionPathParam,
+            availability.sgpServerId && availability.rsoPlatform
+              ? {
+                  sgpServerId: availability.sgpServerId,
+                  rsoPlatformId: availability.rsoPlatform
+                }
+              : undefined
+          )
         )
       }
 
@@ -127,14 +162,6 @@ export class SgpHttpClientController {
         }
       }
     )
-  }
-
-  private _getSubId(sgpServerId: string) {
-    if (sgpServerId.startsWith('TENCENT')) {
-      const [_, rsoPlatformId] = sgpServerId.split('_')
-      return rsoPlatformId
-    }
-    return sgpServerId
   }
 
   private _getToken(tokenType: string) {

--- a/src/main/shards/sgp/token-state-controller.ts
+++ b/src/main/shards/sgp/token-state-controller.ts
@@ -19,12 +19,7 @@ export class SgpTokenStateController {
           return
         }
 
-        const copiedToken = structuredClone(token)
-
-        copiedToken.accessToken = copiedToken.accessToken?.slice(0, 24) + '...'
-        copiedToken.token = copiedToken.token?.slice(0, 24) + '...'
-
-        logger.info(`Update Entitlements Token: ${JSON.stringify(copiedToken)}`)
+        logger.info('Update Entitlements Token: <redacted>')
 
         state.setEntitlementsTokenSet(true)
       },
@@ -43,8 +38,7 @@ export class SgpTokenStateController {
           return
         }
 
-        const copied = token.slice(0, 24) + '...'
-        logger.info(`Update Lol League Session Token: ${copied}`)
+        logger.info('Update Lol League Session Token: <redacted>')
         state.setLeagueSessionTokenSet(true)
       },
       { fireImmediately: true }

--- a/src/main/shards/tray/tray-menu-controller.test.ts
+++ b/src/main/shards/tray/tray-menu-controller.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { TrayMenuController } from './tray-menu-controller'
+
+const electronMocks = vi.hoisted(() => ({
+  quit: vi.fn()
+}))
+
+vi.mock('@resources/LA_ICON.ico?asset', () => ({ default: 'icon.ico' }))
+vi.mock('@resources/iconTemplate.png?asset', () => ({ default: 'iconTemplate.png' }))
+
+vi.mock('electron', () => {
+  class MenuItem {
+    constructor(options: Record<string, unknown>) {
+      Object.assign(this, options)
+    }
+  }
+
+  class Tray {
+    addListener = vi.fn()
+    destroy = vi.fn()
+    setToolTip = vi.fn()
+  }
+
+  return {
+    app: { name: 'League Akari', quit: electronMocks.quit },
+    Menu: {
+      buildFromTemplate: vi.fn((template) => template),
+      setApplicationMenu: vi.fn()
+    },
+    MenuItem,
+    Tray,
+    nativeImage: {
+      createFromPath: vi.fn()
+    }
+  }
+})
+
+vi.mock('i18next', () => ({
+  default: { t: (key: string) => key }
+}))
+
+vi.mock('../app-common', () => ({
+  AppCommonMain: { id: 'app-common-main' }
+}))
+
+function createController() {
+  const noOpWindow = {
+    settings: { enabled: true },
+    close: vi.fn(),
+    repositionWindowIfInvisible: vi.fn(),
+    showOrRestore: vi.fn(),
+    toggleDevtools: vi.fn()
+  }
+  const mainWindow = { ...noOpWindow, close: vi.fn() }
+
+  const context = {
+    ipc: { sendEvent: vi.fn() },
+    windowManager: {
+      auxWindow: noOpWindow,
+      cdTimerWindow: noOpWindow,
+      mainWindow,
+      ongoingGameWindow: noOpWindow,
+      opggWindow: noOpWindow
+    }
+  }
+
+  return {
+    controller: new TrayMenuController(context as any),
+    mainWindow
+  }
+}
+
+describe('TrayMenuController', () => {
+  beforeEach(() => {
+    electronMocks.quit.mockReset()
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+  })
+
+  test('the Quit item quits the application instead of only closing the main window', () => {
+    const { controller, mainWindow } = createController()
+    controller.build()
+
+    ;(controller.quitTrayItem as any).click()
+
+    expect(electronMocks.quit).toHaveBeenCalledOnce()
+    expect(mainWindow.close).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/shards/tray/tray-menu-controller.ts
+++ b/src/main/shards/tray/tray-menu-controller.ts
@@ -90,7 +90,7 @@ export class TrayMenuController {
     this.quitTrayItem = new MenuItem({
       label: i18next.t('tray.quit'),
       type: 'normal',
-      click: () => windowManager.mainWindow.close(true)
+      click: () => app.quit()
     })
 
     this._contextMenu = Menu.buildFromTemplate([

--- a/src/main/shards/window-manager/base-akari-window.ts
+++ b/src/main/shards/window-manager/base-akari-window.ts
@@ -28,6 +28,7 @@ import { SettingSchema } from '../setting-factory'
 import { SetterSettingService } from '../setting-factory/setter-setting-service'
 import type { WindowManagerMainContext } from './context'
 import { repositionWindowIfInvisible } from './window-position-service'
+import { showOrRestoreWindow } from './window-visibility'
 
 /**
  * 具备的一些基础属性
@@ -614,23 +615,7 @@ export abstract class BaseAkariWindow<
 
   showOrRestore(inactive = false) {
     if (this._window) {
-      if (!this.state.show) {
-        if (inactive) {
-          this._window.showInactive()
-        } else {
-          this._window.show()
-        }
-
-        return
-      }
-
-      if (this._window.isMinimized()) {
-        this._window.restore()
-      }
-
-      if (!inactive) {
-        this._window.focus()
-      }
+      showOrRestoreWindow(this._window, inactive)
     }
   }
 

--- a/src/main/shards/window-manager/cd-timer-window/windows.ts
+++ b/src/main/shards/window-manager/cd-timer-window/windows.ts
@@ -7,6 +7,7 @@ import { comparer, computed } from 'mobx'
 
 import { BaseAkariWindow } from '../base-akari-window'
 import type { WindowManagerMainContext } from '../context'
+import { shouldShowOverlayOnAllWorkspaces } from '../platform'
 import { CdTimerWindowSettings, CdTimerWindowState } from './state'
 
 export class AkariCdTimerWindow extends BaseAkariWindow<CdTimerWindowState, CdTimerWindowSettings> {
@@ -100,6 +101,10 @@ export class AkariCdTimerWindow extends BaseAkariWindow<CdTimerWindowState, CdTi
       () => this.state.ready,
       (ready) => {
         if (ready) {
+          if (shouldShowOverlayOnAllWorkspaces()) {
+            this._window?.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })
+          }
+
           this._applyOverlayWindowBehavior()
 
           this._window?.on('show', () => {
@@ -145,10 +150,6 @@ export class AkariCdTimerWindow extends BaseAkariWindow<CdTimerWindowState, CdTi
         if (!shortcut) {
           this._logger.debug('Unregister cd-timer window shortcut')
           this._keyboardShortcuts.unregisterByTargetId(this.shortcutTargetId)
-          return
-        }
-
-        if (!NATIVE_SUPPORT.nativeInput.available) {
           return
         }
 

--- a/src/main/shards/window-manager/ongoing-game-window/window.ts
+++ b/src/main/shards/window-manager/ongoing-game-window/window.ts
@@ -6,6 +6,7 @@ import { comparer } from 'mobx'
 
 import { BaseAkariWindow } from '../base-akari-window'
 import type { WindowManagerMainContext } from '../context'
+import { shouldShowOverlayOnAllWorkspaces } from '../platform'
 import { OngoingGameWindowSettings, OngoingGameWindowState } from './state'
 
 export class AkariOngoingGameWindow extends BaseAkariWindow<
@@ -102,6 +103,10 @@ export class AkariOngoingGameWindow extends BaseAkariWindow<
         }
 
         if (this._window) {
+          if (shouldShowOverlayOnAllWorkspaces()) {
+            this._window.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true })
+          }
+
           this._window.setIgnoreMouseEvents(true)
           this.show()
         }

--- a/src/main/shards/window-manager/platform.test.ts
+++ b/src/main/shards/window-manager/platform.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldShowOverlayOnAllWorkspaces } from './platform'
+
+describe('window manager platform guards', () => {
+  it('uses the macOS all-Spaces behavior only on macOS', () => {
+    expect(shouldShowOverlayOnAllWorkspaces('darwin')).toBe(true)
+    expect(shouldShowOverlayOnAllWorkspaces('win32')).toBe(false)
+    expect(shouldShowOverlayOnAllWorkspaces('linux')).toBe(false)
+  })
+})

--- a/src/main/shards/window-manager/platform.ts
+++ b/src/main/shards/window-manager/platform.ts
@@ -1,0 +1,3 @@
+export function shouldShowOverlayOnAllWorkspaces(platform: NodeJS.Platform = process.platform) {
+  return platform === 'darwin'
+}

--- a/src/main/shards/window-manager/window-position-service.test.ts
+++ b/src/main/shards/window-manager/window-position-service.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { repositionToAlignLeagueClientUx } from './window-position-service'
+
+const nativeMock = vi.hoisted(() => ({
+  placementAvailable: false,
+  getLeagueClientWindowPlacement: vi.fn()
+}))
+
+vi.mock('@main/native', () => ({
+  NATIVE_SUPPORT: {
+    getLeagueClientWindowPlacement: {
+      get available() {
+        return nativeMock.placementAvailable
+      }
+    }
+  },
+  getLeagueClientWindowPlacement: nativeMock.getLeagueClientWindowPlacement
+}))
+
+vi.mock('electron', () => ({
+  BrowserWindow: class {},
+  screen: {
+    getAllDisplays: vi.fn(),
+    getDisplayMatching: vi.fn(),
+    getPrimaryDisplay: vi.fn()
+  }
+}))
+
+describe('repositionToAlignLeagueClientUx', () => {
+  beforeEach(() => {
+    nativeMock.placementAvailable = false
+    nativeMock.getLeagueClientWindowPlacement.mockReset()
+  })
+
+  it('does not call the Win32 placement API when the capability is unavailable', () => {
+    repositionToAlignLeagueClientUx({} as any)
+
+    expect(nativeMock.getLeagueClientWindowPlacement).not.toHaveBeenCalled()
+  })
+
+  it('preserves placement lookup when the capability is available', () => {
+    nativeMock.placementAvailable = true
+    nativeMock.getLeagueClientWindowPlacement.mockReturnValue(null)
+
+    repositionToAlignLeagueClientUx({} as any)
+
+    expect(nativeMock.getLeagueClientWindowPlacement).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/shards/window-manager/window-position-service.ts
+++ b/src/main/shards/window-manager/window-position-service.ts
@@ -202,7 +202,7 @@ export function repositionToAlignLeagueClientUx(
   win: BrowserWindow,
   placement?: 'top-left' | 'bottom-left' | 'top-right' | 'bottom-right'
 ) {
-  if (!NATIVE_SUPPORT.getLeagueClientWindowPlacement) return
+  if (!NATIVE_SUPPORT.getLeagueClientWindowPlacement.available) return
 
   const info = getLeagueClientWindowPlacement()
   if (info) {

--- a/src/main/shards/window-manager/window-visibility.test.ts
+++ b/src/main/shards/window-manager/window-visibility.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { showOrRestoreWindow } from './window-visibility'
+
+function createWindow(options: { minimized?: boolean; visible?: boolean } = {}) {
+  return {
+    focus: vi.fn(),
+    isMinimized: vi.fn(() => options.minimized ?? false),
+    isVisible: vi.fn(() => options.visible ?? true),
+    restore: vi.fn(),
+    show: vi.fn(),
+    showInactive: vi.fn()
+  }
+}
+
+describe('showOrRestoreWindow', () => {
+  it('restores a minimized hidden window before showing and focusing it', () => {
+    const window = createWindow({ minimized: true, visible: false })
+
+    showOrRestoreWindow(window as Parameters<typeof showOrRestoreWindow>[0])
+
+    expect(window.restore).toHaveBeenCalledOnce()
+    expect(window.show).toHaveBeenCalledOnce()
+    expect(window.focus).toHaveBeenCalledOnce()
+    expect(window.restore.mock.invocationCallOrder[0]).toBeLessThan(
+      window.show.mock.invocationCallOrder[0]
+    )
+  })
+
+  it('uses inactive display without stealing focus', () => {
+    const window = createWindow({ visible: false })
+
+    showOrRestoreWindow(window as Parameters<typeof showOrRestoreWindow>[0], true)
+
+    expect(window.showInactive).toHaveBeenCalledOnce()
+    expect(window.show).not.toHaveBeenCalled()
+    expect(window.focus).not.toHaveBeenCalled()
+  })
+
+  it('focuses an already visible window without showing it again', () => {
+    const window = createWindow()
+
+    showOrRestoreWindow(window as Parameters<typeof showOrRestoreWindow>[0])
+
+    expect(window.restore).not.toHaveBeenCalled()
+    expect(window.show).not.toHaveBeenCalled()
+    expect(window.focus).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/shards/window-manager/window-visibility.ts
+++ b/src/main/shards/window-manager/window-visibility.ts
@@ -1,0 +1,24 @@
+import type { BrowserWindow } from 'electron'
+
+type RestorableWindow = Pick<
+  BrowserWindow,
+  'focus' | 'isMinimized' | 'isVisible' | 'restore' | 'show' | 'showInactive'
+>
+
+export function showOrRestoreWindow(window: RestorableWindow, inactive = false) {
+  if (window.isMinimized()) {
+    window.restore()
+  }
+
+  if (!window.isVisible()) {
+    if (inactive) {
+      window.showInactive()
+    } else {
+      window.show()
+    }
+  }
+
+  if (!inactive) {
+    window.focus()
+  }
+}

--- a/src/main/utils/local-client-ipc.test.ts
+++ b/src/main/utils/local-client-ipc.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { LeagueClientIpcHandlers } from '../shards/league-client/ipc-handlers'
+import { RiotClientIpcHandlers } from '../shards/riot-client/ipc-handlers'
+
+type HandlerConstructor = new (context: any) => { register(): void }
+
+function setupRequestHandler(Handler: HandlerConstructor, clientKey: string) {
+  const requestHandlers: Array<(event: unknown, config: { url?: string }) => Promise<unknown>> = []
+  const requestForRenderer = vi.fn(async () => ({ status: 200 }))
+  const context = {
+    namespace: `${clientKey}-main`,
+    ipc: {
+      onCall: vi.fn(
+        (
+          _namespace: string,
+          channel: string,
+          handler: (event: unknown, config: { url?: string }) => Promise<unknown>
+        ) => {
+          if (channel === 'http-request') {
+            requestHandlers.push(handler)
+          }
+        }
+      )
+    },
+    [clientKey]: { requestForRenderer }
+  }
+
+  new Handler(context).register()
+  const requestHandler = requestHandlers[0]
+  if (!requestHandler) {
+    throw new Error('HTTP request handler was not registered')
+  }
+
+  return { requestForRenderer, requestHandler }
+}
+
+describe.each([
+  ['League Client', LeagueClientIpcHandlers, 'leagueClient'],
+  ['Riot Client', RiotClientIpcHandlers, 'riotClient']
+] as const)('%s renderer request proxy', (_name, Handler, clientKey) => {
+  it('rejects an absolute URL before reaching the local TLS client', async () => {
+    const { requestForRenderer, requestHandler } = setupRequestHandler(Handler, clientKey)
+
+    await expect(requestHandler({}, { url: 'https://example.test/not-local' })).rejects.toThrow(
+      'Local client requests require a relative URL'
+    )
+    expect(requestForRenderer).not.toHaveBeenCalled()
+  })
+
+  it('forwards a relative local endpoint', async () => {
+    const { requestForRenderer, requestHandler } = setupRequestHandler(Handler, clientKey)
+    const config = { url: '/riotclient/auth-token' }
+
+    await expect(requestHandler({}, config)).resolves.toEqual({ status: 200 })
+    expect(requestForRenderer).toHaveBeenCalledWith(config)
+  })
+})

--- a/src/main/utils/local-client-url.test.ts
+++ b/src/main/utils/local-client-url.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import { assertLocalClientRequestUrl } from './local-client-url'
+
+describe('local client request URL constraints', () => {
+  it.each([
+    'https://example.test/path',
+    'HTTP://example.test/path',
+    '//example.test/path',
+    '\\\\example.test\\path',
+    'file:///private/tmp/example'
+  ])('rejects non-local URL %s', (url) => {
+    expect(() => assertLocalClientRequestUrl(url)).toThrow(
+      'Local client requests require a relative URL'
+    )
+  })
+
+  it.each(['/lol-summoner/v1/current-summoner', 'riotclient/auth-token', '?query=value'])(
+    'allows relative local endpoint %s',
+    (url) => {
+      expect(() => assertLocalClientRequestUrl(url)).not.toThrow()
+    }
+  )
+})

--- a/src/main/utils/local-client-url.ts
+++ b/src/main/utils/local-client-url.ts
@@ -1,0 +1,23 @@
+const URL_SCHEME_PATTERN = /^[A-Za-z][A-Za-z\d+.-]*:/
+
+/**
+ * Local Riot/LCU clients may only receive relative endpoint paths.
+ *
+ * Axios normally lets an absolute request URL override `baseURL`. Rejecting schemes and
+ * protocol-relative paths keeps the clients' self-signed-certificate exception scoped to their
+ * loopback origins, including for renderer-proxied requests.
+ */
+export function assertLocalClientRequestUrl(url: string | undefined) {
+  if (!url) {
+    return
+  }
+
+  const normalized = url.trim()
+  if (
+    URL_SCHEME_PATTERN.test(normalized) ||
+    normalized.startsWith('//') ||
+    normalized.startsWith('\\\\')
+  ) {
+    throw new TypeError('Local client requests require a relative URL')
+  }
+}

--- a/src/renderer-shared/shards/app-common/store.ts
+++ b/src/renderer-shared/shards/app-common/store.ts
@@ -53,6 +53,11 @@ export const useAppCommonStore = defineStore('shard:app-common-renderer', () => 
       availableOnCurrentPlatform: false,
       requiresElevation: false
     },
+    activationShortcut: {
+      available: false,
+      availableOnCurrentPlatform: false,
+      requiresElevation: false
+    },
     getLeagueClientWindowPlacement: {
       available: false,
       availableOnCurrentPlatform: false,

--- a/src/renderer/src-main-window/components/ShortcutSelector.vue
+++ b/src/renderer/src-main-window/components/ShortcutSelector.vue
@@ -73,15 +73,15 @@
       </div>
     </NModal>
 
-    <NPopover :disabled="as.nativeSupport.nativeInput.available">
+    <NPopover :disabled="shortcutSelectionAvailable">
       <template #trigger>
         <NButton
           size="tiny"
-          :disabled="!as.nativeSupport.nativeInput.available"
+          :disabled="!shortcutSelectionAvailable"
           type="primary"
           @click="
             () => {
-              if (!as.nativeSupport.nativeInput.available) return
+              if (!shortcutSelectionAvailable) return
               show = true
             }
           "
@@ -89,9 +89,9 @@
           {{ t('settings.shortcutSelector.select') }}
         </NButton>
       </template>
-      <template v-if="!as.nativeSupport.nativeInput.available">
+      <template v-if="!shortcutSelectionAvailable">
         {{
-          nativeInputRequiresElevation
+          shortcutRequiresElevation
             ? t('settings.shortcutSelector.notRunAsAdministrator')
             : t('settings.shortcutSelector.nativeGlobalShortcutsWindowsOnly')
         }}
@@ -120,20 +120,32 @@
 import { useInstance } from '@renderer-shared/shards'
 import { useAppCommonStore } from '@renderer-shared/shards/app-common/store'
 import { KeyboardShortcutsRenderer } from '@renderer-shared/shards/keyboard-shortcut'
+import { keyboardEventToActivationShortcutId } from '@shared/utils/activation-shortcuts'
 import { useTranslation } from 'i18next-vue'
 import { NButton, NModal, NPopover } from 'naive-ui'
 import { computed, onDeactivated, onUnmounted, ref, shallowRef, watch } from 'vue'
 
-defineProps<{
-  targetId?: string
-}>()
+const props = withDefaults(
+  defineProps<{
+    activationOnly?: boolean
+    targetId?: string
+  }>(),
+  { activationOnly: false }
+)
 
 const { t } = useTranslation()
 
 const as = useAppCommonStore()
 
-const nativeInputRequiresElevation = computed(
-  () => as.nativeSupport.nativeInput.requiresElevation && !as.isElevated
+const shortcutCapability = computed(() =>
+  props.activationOnly ? as.nativeSupport.activationShortcut : as.nativeSupport.nativeInput
+)
+const shortcutSelectionAvailable = computed(() => shortcutCapability.value.available)
+const shortcutRequiresElevation = computed(
+  () =>
+    shortcutCapability.value.availableOnCurrentPlatform &&
+    shortcutCapability.value.requiresElevation &&
+    !as.isElevated
 )
 
 const kbd = useInstance(KeyboardShortcutsRenderer)
@@ -156,7 +168,7 @@ const keys = computed(() => {
   return shortcutId.value?.split('+') ?? []
 })
 
-let handler: () => void
+let handler: (() => void) | undefined
 
 const preventFn = (event: KeyboardEvent) => {
   const { key, altKey, ctrlKey, metaKey, shiftKey } = event
@@ -189,6 +201,16 @@ const preventFn = (event: KeyboardEvent) => {
   }
 }
 
+const captureActivationShortcut = (event: KeyboardEvent) => {
+  event.preventDefault()
+  event.stopPropagation()
+
+  const capturedShortcutId = keyboardEventToActivationShortcutId(event)
+  if (capturedShortcutId) {
+    currentShortcutId.value = capturedShortcutId
+  }
+}
+
 const isOccupiedBy = shallowRef<{
   type: 'last-active' | 'normal' | 'stateful'
   targetId: string
@@ -210,18 +232,26 @@ watch(
   () => show.value,
   async () => {
     if (show.value) {
+      currentShortcutId.value = shortcutId.value
+
       if (currentShortcutId.value) {
         isOccupiedBy.value = await kbd.getRegistration(currentShortcutId.value)
       }
 
-      currentShortcutId.value = shortcutId.value
-      handler = kbd.onShortcut((event) => {
-        currentShortcutId.value = event.id
-      })
-      window.addEventListener('keydown', preventFn)
+      if (as.nativeSupport.nativeInput.available) {
+        handler = kbd.onShortcut((event) => {
+          currentShortcutId.value = event.id
+        })
+        window.addEventListener('keydown', preventFn)
+      } else if (props.activationOnly && as.nativeSupport.activationShortcut.available) {
+        window.addEventListener('keydown', captureActivationShortcut)
+        handler = () => window.removeEventListener('keydown', captureActivationShortcut)
+      }
     } else {
       handler?.()
+      handler = undefined
       window.removeEventListener('keydown', preventFn)
+      window.removeEventListener('keydown', captureActivationShortcut)
       isOccupiedBy.value = null
     }
   },
@@ -231,6 +261,7 @@ watch(
 onUnmounted(() => {
   handler?.()
   window.removeEventListener('keydown', preventFn)
+  window.removeEventListener('keydown', captureActivationShortcut)
 })
 
 onDeactivated(() => {

--- a/src/renderer/src-main-window/components/settings-modal/DebugSettings.vue
+++ b/src/renderer/src-main-window/components/settings-modal/DebugSettings.vue
@@ -129,7 +129,7 @@
               </tr>
               <tr>
                 <td>{{ t('settings.debug.lcuConnection.auth') }}</td>
-                <td><CopyableText :text="lc.auth?.authToken ?? '-'" /></td>
+                <td>{{ lc.auth ? REDACTED_SECRET : '-' }}</td>
               </tr>
               <tr>
                 <td>{{ t('settings.debug.lcuConnection.rsoPlatform') }}</td>
@@ -253,6 +253,7 @@ import { useInstance } from '@renderer-shared/shards'
 import { AppCommonRenderer } from '@renderer-shared/shards/app-common'
 import { useAppCommonStore } from '@renderer-shared/shards/app-common/store'
 import { useLeagueClientStore } from '@renderer-shared/shards/league-client/store'
+import { REDACTED_SECRET } from '@shared/utils/redact-secrets'
 import { LoggerRenderer } from '@renderer-shared/shards/logger'
 import { RendererDebugRenderer } from '@renderer-shared/shards/renderer-debug'
 import { useRendererDebugStore } from '@renderer-shared/shards/renderer-debug/store'

--- a/src/renderer/src-main-window/components/settings-modal/MultiWindowSettings.vue
+++ b/src/renderer/src-main-window/components/settings-modal/MultiWindowSettings.vue
@@ -107,12 +107,13 @@
           />
         </SettingsRow>
         <SettingsRow
-          :disabled="!as.nativeSupport.nativeInput.available"
+          :disabled="!as.nativeSupport.activationShortcut.available"
           :label-width="400"
           :label="t('settings.multiWindow.opggWindow.showShortcut.label')"
           :label-description="t('settings.multiWindow.opggWindow.showShortcut.description')"
         >
           <ShortcutSelector
+            activation-only
             :target-id="AkariOpggWindow.SHOW_WINDOW_SHORTCUT_TARGET_ID"
             :shortcut-id="ows.settings.showShortcut"
             @update:shortcut-id="(id) => wm.opggWindow.setShowShortcut(id)"
@@ -150,17 +151,27 @@
       </SettingsSection>
       <SettingsSection
         :title="
-          as.isElevated
-            ? t('settings.multiWindow.ongoingGameWindow.title')
-            : t('settings.multiWindow.ongoingGameWindow.titleRequireAdmin')
+          nativeInputRequiresElevation
+            ? t('settings.multiWindow.ongoingGameWindow.titleRequireAdmin')
+            : t('settings.multiWindow.ongoingGameWindow.title')
         "
       >
         <SettingsRow
+          :disabled="!as.nativeSupport.nativeInput.available"
           :label="t('settings.multiWindow.ongoingGameWindow.enabled.label')"
-          :label-description="t('settings.multiWindow.ongoingGameWindow.enabled.description')"
           :label-width="400"
         >
+          <template #labelDescription>
+            <div>{{ t('settings.multiWindow.ongoingGameWindow.enabled.description') }}</div>
+            <div
+              v-if="!as.nativeSupport.nativeInput.available"
+              class="mt-1 text-xs text-yellow-700/80 dark:text-yellow-300/80"
+            >
+              {{ ongoingGameWindowUnavailableReason }}
+            </div>
+          </template>
           <NSwitch
+            :disabled="!as.nativeSupport.nativeInput.available"
             size="small"
             :value="ogws.settings.enabled"
             @update:value="(val) => wm.ongoingGameWindow.setEnabled(val)"
@@ -179,13 +190,7 @@
           />
         </SettingsRow>
       </SettingsSection>
-      <SettingsSection
-        :title="
-          as.isElevated
-            ? t('settings.multiWindow.cdTimerWindow.title')
-            : t('settings.multiWindow.cdTimerWindow.titleRequireAdmin')
-        "
-      >
+      <SettingsSection :title="t('settings.multiWindow.cdTimerWindow.title')">
         <SettingsRow
           :label="t('settings.multiWindow.cdTimerWindow.enabled.label')"
           :label-description="t('settings.multiWindow.cdTimerWindow.enabled.description')"
@@ -198,12 +203,13 @@
           />
         </SettingsRow>
         <SettingsRow
-          :disabled="!as.nativeSupport.nativeInput.available"
+          :disabled="!as.nativeSupport.activationShortcut.available"
           :label-width="400"
           :label="t('settings.multiWindow.cdTimerWindow.showShortcut.label')"
           :label-description="t('settings.multiWindow.cdTimerWindow.showShortcut.description')"
         >
           <ShortcutSelector
+            activation-only
             :target-id="AkariCdTimerWindow.SHOW_WINDOW_SHORTCUT_TARGET_ID"
             :shortcut-id="ctws.settings.showShortcut"
             @update:shortcut-id="(id) => wm.cdTimerWindow.setShowShortcut(id)"
@@ -289,6 +295,7 @@ import {
 import { Window24Filled as Window24FilledIcon } from '@vicons/fluent'
 import { TranslationComponent, useTranslation } from 'i18next-vue'
 import { NButton, NIcon, NRadio, NRadioGroup, NScrollbar, NSlider, NSwitch } from 'naive-ui'
+import { computed } from 'vue'
 
 import ShortcutSelector from '@main-window/components/ShortcutSelector.vue'
 
@@ -299,6 +306,18 @@ const aws = useAuxWindowStore()
 const ows = useOpggWindowStore()
 const ogws = useOngoingGameWindowStore()
 const ctws = useCdTimerWindowStore()
+
+const nativeInputRequiresElevation = computed(
+  () =>
+    as.nativeSupport.nativeInput.availableOnCurrentPlatform &&
+    as.nativeSupport.nativeInput.requiresElevation &&
+    !as.isElevated
+)
+const ongoingGameWindowUnavailableReason = computed(() =>
+  as.nativeSupport.nativeInput.availableOnCurrentPlatform
+    ? t('settings.multiWindow.ongoingGameWindow.requiresAdministrator')
+    : t('settings.multiWindow.ongoingGameWindow.unsupportedCurrentPlatform')
+)
 
 const wm = useInstance(WindowManagerRenderer)
 </script>

--- a/src/renderer/src-main-window/shards/simple-notifications/platform.test.ts
+++ b/src/renderer/src-main-window/shards/simple-notifications/platform.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  shouldShowCannotGetUxCommandLineWarning,
+  shouldShowWmiAdministratorPrompt
+} from './platform'
+
+describe('simple notification platform guards', () => {
+  it('does not offer Windows administrator or WMI flows on macOS', () => {
+    expect(shouldShowWmiAdministratorPrompt('darwin', true, false)).toBe(false)
+    expect(shouldShowCannotGetUxCommandLineWarning('darwin', true, true)).toBe(false)
+  })
+
+  it('keeps the existing Windows warning conditions', () => {
+    expect(shouldShowWmiAdministratorPrompt('win32', true, false)).toBe(true)
+    expect(shouldShowWmiAdministratorPrompt('win32', true, true)).toBe(false)
+    expect(shouldShowCannotGetUxCommandLineWarning('win32', true, true)).toBe(true)
+    expect(shouldShowCannotGetUxCommandLineWarning('win32', false, true)).toBe(false)
+  })
+})

--- a/src/renderer/src-main-window/shards/simple-notifications/platform.ts
+++ b/src/renderer/src-main-window/shards/simple-notifications/platform.ts
@@ -1,0 +1,17 @@
+import type { AkariSupportedPlatform } from '@shared/types/common'
+
+export function shouldShowWmiAdministratorPrompt(
+  platform: AkariSupportedPlatform,
+  useWmi: boolean,
+  isElevated: boolean
+) {
+  return platform === 'win32' && useWmi && !isElevated
+}
+
+export function shouldShowCannotGetUxCommandLineWarning(
+  platform: AkariSupportedPlatform,
+  hasClientButNoCommandLine: boolean,
+  isLeagueClientDisconnected: boolean
+) {
+  return platform === 'win32' && hasClientButNoCommandLine && isLeagueClientDisconnected
+}

--- a/src/renderer/src-main-window/shards/simple-notifications/system-warning-dialogs.tsx
+++ b/src/renderer/src-main-window/shards/simple-notifications/system-warning-dialogs.tsx
@@ -18,6 +18,10 @@ import {
   SIMPLE_NOTIFICATIONS_RENDERER_ID,
   type SimpleNotificationsRendererContext
 } from './context'
+import {
+  shouldShowCannotGetUxCommandLineWarning,
+  shouldShowWmiAdministratorPrompt
+} from './platform'
 import { useSimpleNotificationsStore } from './store'
 
 export function watchAskUserToRunAsAdministrator() {
@@ -31,7 +35,11 @@ export function watchAskUserToRunAsAdministrator() {
   const appCommon = useInstance(AppCommonRenderer)
 
   const shouldAsk = computed(() => {
-    return leagueClientUxStore.settings.useWmi && !appCommonStore.isElevated
+    return shouldShowWmiAdministratorPrompt(
+      appCommonStore.platform,
+      leagueClientUxStore.settings.useWmi,
+      appCommonStore.isElevated
+    )
   })
 
   watch(
@@ -69,14 +77,18 @@ export function watchCannotGetUxCommandLine() {
   const appCommon = useInstance(AppCommonRenderer)
 
   let dialogReactive: DialogReactive | null = null
+  const shouldWarn = computed(() =>
+    shouldShowCannotGetUxCommandLineWarning(
+      appCommonStore.platform,
+      leagueClientUxStore.hasClientButNoCommandLine,
+      leagueClientStore.isDisconnected
+    )
+  )
+
   watch(
-    [
-      () => leagueClientUxStore.hasClientButNoCommandLine,
-      () =>
-        leagueClientStore.isDisconnected /* 在退出 leagueClientUx 后，leagueClient 仍然会短暂停留并处理善后工作，考虑仅限未连接才会触发此提示 */
-    ],
-    ([hasClientButNoCommandLine, isDisconnected]) => {
-      if (hasClientButNoCommandLine && isDisconnected) {
+    () => shouldWarn.value,
+    (shouldShow) => {
+      if (shouldShow) {
         if (leagueClientUxStore.settings.useWmi) {
           dialogReactive = dialog.warning({
             style: { width: '600px' },

--- a/src/renderer/src-main-window/views/toolkit/client/Client.vue
+++ b/src/renderer/src-main-window/views/toolkit/client/Client.vue
@@ -186,7 +186,10 @@ const nativeInputStatusDescription = computed(() =>
 
 const adjustWindowRequirement = computed(() => as.nativeSupport.adjustLeagueClientWindowSize)
 const adjustWindowRequiresElevation = computed(
-  () => adjustWindowRequirement.value.requiresElevation && !as.isElevated
+  () =>
+    adjustWindowRequirement.value.availableOnCurrentPlatform &&
+    adjustWindowRequirement.value.requiresElevation &&
+    !as.isElevated
 )
 const adjustLeagueClientWindowSizeSupported = computed(
   () => adjustWindowRequirement.value.available

--- a/src/shared/i18n/en/renderer/settings.yaml
+++ b/src/shared/i18n/en/renderer/settings.yaml
@@ -322,6 +322,8 @@ settings:
     ongoingGameWindow:
       title: Ongoing Game Overlay Window
       titleRequireAdmin: Ongoing Game Overlay Window (Admin Required)
+      requiresAdministrator: The hold-to-show overlay requires the native keyboard hook and administrator privileges.
+      unsupportedCurrentPlatform: The hold-to-show overlay requires native key press and release events, which are not supported on this platform.
       enabled:
         label: Enable Ongoing Game Window
         description: Display an overlay window during the game to show ongoing game information. This feature requires the game client to be in windowed or borderless mode.

--- a/src/shared/i18n/zh-CN/renderer/settings.yaml
+++ b/src/shared/i18n/zh-CN/renderer/settings.yaml
@@ -320,6 +320,8 @@ settings:
     ongoingGameWindow:
       title: 对局叠加窗口
       titleRequireAdmin: 对局叠加窗口 (管理员权限)
+      requiresAdministrator: 长按显示叠加窗口依赖原生键盘钩子，需要以管理员权限运行。
+      unsupportedCurrentPlatform: 长按显示叠加窗口需要原生按键按下与松开事件，当前平台不支持。
       enabled:
         label: 启用对局窗口
         description: 在游戏中时，通过叠加窗口展示对局信息。若无法正常显示，需启用游戏的无边框或窗口模式

--- a/src/shared/types/common.ts
+++ b/src/shared/types/common.ts
@@ -13,6 +13,7 @@ type NativeSupportRequirement = {
 
 export interface NativeSupport {
   nativeInput: NativeSupportRequirement
+  activationShortcut: NativeSupportRequirement
   getLeagueClientWindowPlacement: NativeSupportRequirement
   adjustLeagueClientWindowSize: NativeSupportRequirement
   isProcessForeground: NativeSupportRequirement

--- a/src/shared/utils/activation-shortcuts.test.ts
+++ b/src/shared/utils/activation-shortcuts.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  keyboardEventToActivationShortcutId,
+  shortcutIdToElectronAccelerator
+} from './activation-shortcuts'
+
+describe('activation shortcuts', () => {
+  it('converts the persisted key ids to Electron accelerators', () => {
+    expect(shortcutIdToElectronAccelerator('LeftMeta+Shift+K')).toBe('Command+Shift+K')
+    expect(shortcutIdToElectronAccelerator('LeftControl+RightControl+A')).toBe('Control+A')
+    expect(shortcutIdToElectronAccelerator('Alt+LeftArrow')).toBe('Alt+Left')
+  })
+
+  it('rejects modifier-only, multi-key, and unsupported key combinations', () => {
+    expect(shortcutIdToElectronAccelerator('LeftMeta')).toBeNull()
+    expect(shortcutIdToElectronAccelerator('A+B')).toBeNull()
+    expect(shortcutIdToElectronAccelerator('LeftMeta+Numpad1')).toBeNull()
+  })
+
+  it('captures a macOS Command shortcut from a renderer keyboard event', () => {
+    expect(
+      keyboardEventToActivationShortcutId({
+        code: 'KeyK',
+        altKey: false,
+        ctrlKey: false,
+        metaKey: true,
+        shiftKey: true
+      })
+    ).toBe('LeftMeta+Shift+K')
+  })
+
+  it('ignores repeats and modifier-only keydown events', () => {
+    expect(
+      keyboardEventToActivationShortcutId({
+        code: 'KeyK',
+        altKey: false,
+        ctrlKey: false,
+        metaKey: true,
+        shiftKey: false,
+        repeat: true
+      })
+    ).toBeNull()
+    expect(
+      keyboardEventToActivationShortcutId({
+        code: 'MetaLeft',
+        altKey: false,
+        ctrlKey: false,
+        metaKey: true,
+        shiftKey: false
+      })
+    ).toBeNull()
+  })
+})

--- a/src/shared/utils/activation-shortcuts.ts
+++ b/src/shared/utils/activation-shortcuts.ts
@@ -1,0 +1,164 @@
+const ELECTRON_MODIFIER_BY_KEY_ID: Record<string, string> = {
+  Control: 'Control',
+  LeftControl: 'Control',
+  RightControl: 'Control',
+  Shift: 'Shift',
+  LeftShift: 'Shift',
+  RightShift: 'Shift',
+  Alt: 'Alt',
+  LeftAlt: 'Alt',
+  RightAlt: 'Alt',
+  LeftMeta: 'Command',
+  RightMeta: 'Command'
+}
+
+const ELECTRON_KEY_BY_KEY_ID: Record<string, string> = {
+  Backspace: 'Backspace',
+  Tab: 'Tab',
+  Enter: 'Enter',
+  Pause: 'Pause',
+  CapsLock: 'CapsLock',
+  Escape: 'Escape',
+  Space: 'Space',
+  PageUp: 'PageUp',
+  PageDown: 'PageDown',
+  End: 'End',
+  Home: 'Home',
+  LeftArrow: 'Left',
+  UpArrow: 'Up',
+  RightArrow: 'Right',
+  DownArrow: 'Down',
+  PrintScreen: 'PrintScreen',
+  Insert: 'Insert',
+  Delete: 'Delete',
+  Semicolon: ';',
+  Equals: '=',
+  Comma: ',',
+  Minus: '-',
+  Dot: '.',
+  ForwardSlash: '/',
+  OpenBracket: '[',
+  Backslash: '\\',
+  CloseBracket: ']',
+  Quote: "'",
+  Backtick: '`'
+}
+
+const KEY_ID_BY_KEYBOARD_CODE: Record<string, string> = {
+  Backspace: 'Backspace',
+  Tab: 'Tab',
+  Enter: 'Enter',
+  Pause: 'Pause',
+  CapsLock: 'CapsLock',
+  Escape: 'Escape',
+  Space: 'Space',
+  PageUp: 'PageUp',
+  PageDown: 'PageDown',
+  End: 'End',
+  Home: 'Home',
+  ArrowLeft: 'LeftArrow',
+  ArrowUp: 'UpArrow',
+  ArrowRight: 'RightArrow',
+  ArrowDown: 'DownArrow',
+  PrintScreen: 'PrintScreen',
+  Insert: 'Insert',
+  Delete: 'Delete',
+  Semicolon: 'Semicolon',
+  Equal: 'Equals',
+  Comma: 'Comma',
+  Minus: 'Minus',
+  Period: 'Dot',
+  Slash: 'ForwardSlash',
+  BracketLeft: 'OpenBracket',
+  Backslash: 'Backslash',
+  BracketRight: 'CloseBracket',
+  Quote: 'Quote',
+  Backquote: 'Backtick'
+}
+
+export const ACTIVATION_SHORTCUT_MODIFIER_KEY_IDS = new Set(
+  Object.keys(ELECTRON_MODIFIER_BY_KEY_ID)
+)
+
+function keyboardCodeToKeyId(code: string) {
+  if (/^Key[A-Z]$/.test(code)) {
+    return code.slice(3)
+  }
+
+  if (/^Digit[0-9]$/.test(code)) {
+    return code.slice(5)
+  }
+
+  if (/^F(?:[1-9]|1[0-2])$/.test(code)) {
+    return code
+  }
+
+  return KEY_ID_BY_KEYBOARD_CODE[code] ?? null
+}
+
+function keyIdToElectronKey(keyId: string) {
+  if (/^[A-Z0-9]$/.test(keyId) || /^F(?:[1-9]|1[0-2])$/.test(keyId)) {
+    return keyId
+  }
+
+  return ELECTRON_KEY_BY_KEY_ID[keyId] ?? null
+}
+
+export function shortcutIdToElectronAccelerator(shortcutId: string) {
+  const modifiers = new Set<string>()
+  let key: string | null = null
+
+  for (const keyId of shortcutId.split('+')) {
+    const modifier = ELECTRON_MODIFIER_BY_KEY_ID[keyId]
+    if (modifier) {
+      modifiers.add(modifier)
+      continue
+    }
+
+    const electronKey = keyIdToElectronKey(keyId)
+    if (!electronKey || key) {
+      return null
+    }
+
+    key = electronKey
+  }
+
+  if (!key) {
+    return null
+  }
+
+  return [...modifiers, key].join('+')
+}
+
+export function isActivationShortcutIdSupported(shortcutId: string) {
+  return shortcutIdToElectronAccelerator(shortcutId) !== null
+}
+
+export interface ShortcutKeyboardEventLike {
+  code: string
+  altKey: boolean
+  ctrlKey: boolean
+  metaKey: boolean
+  shiftKey: boolean
+  repeat?: boolean
+}
+
+export function keyboardEventToActivationShortcutId(event: ShortcutKeyboardEventLike) {
+  if (event.repeat) {
+    return null
+  }
+
+  const keyId = keyboardCodeToKeyId(event.code)
+  if (!keyId) {
+    return null
+  }
+
+  const modifiers: string[] = []
+  if (event.metaKey) modifiers.push('LeftMeta')
+  if (event.ctrlKey) modifiers.push('Control')
+  if (event.shiftKey) modifiers.push('Shift')
+  if (event.altKey) modifiers.push('Alt')
+
+  const shortcutId = [...modifiers, keyId].join('+')
+  return isActivationShortcutIdSupported(shortcutId) ? shortcutId : null
+}

--- a/src/shared/utils/redact-secrets.test.ts
+++ b/src/shared/utils/redact-secrets.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  REDACTED_SECRET,
+  createSecretRedactingJsonReplacer,
+  redactSecretsInString
+} from './redact-secrets'
+
+const LCU_TOKEN = 'synthetic-lcu-token_DO_NOT_USE'
+const RIOT_TOKEN = 'synthetic-riot-token_DO_NOT_USE'
+
+describe('secret redaction', () => {
+  it('redacts Riot and LCU command-line credentials', () => {
+    const commandLine = [
+      '/Applications/League of Legends.app/Contents/MacOS/LeagueClientUx',
+      `--remoting-auth-token=${LCU_TOKEN}`,
+      `--riotclient-auth-token="${RIOT_TOKEN}"`
+    ].join(' ')
+
+    const redacted = redactSecretsInString(commandLine)
+
+    expect(redacted).not.toContain(LCU_TOKEN)
+    expect(redacted).not.toContain(RIOT_TOKEN)
+    expect(redacted).toContain(`--remoting-auth-token=${REDACTED_SECRET}`)
+    expect(redacted).toContain(`--riotclient-auth-token=${REDACTED_SECRET}`)
+  })
+
+  it('redacts authorization headers and loopback websocket credentials', () => {
+    const value = `Authorization: Basic ${RIOT_TOKEN} wss://riot:${LCU_TOKEN}@127.0.0.1:12345 https://riot:${RIOT_TOKEN}@localhost:54321`
+    const redacted = redactSecretsInString(value)
+
+    expect(redacted).not.toContain(LCU_TOKEN)
+    expect(redacted).not.toContain(RIOT_TOKEN)
+    expect(redacted).toContain(`Basic ${REDACTED_SECRET}`)
+    expect(redacted).toContain(`wss://riot:${REDACTED_SECRET}@127.0.0.1:12345`)
+    expect(redacted).toContain(`https://riot:${REDACTED_SECRET}@localhost:54321`)
+  })
+
+  it('redacts sensitive object fields during serialization', () => {
+    const serialized = JSON.stringify(
+      {
+        authToken: LCU_TOKEN,
+        nested: { riotClientAuthToken: RIOT_TOKEN },
+        port: 12345
+      },
+      createSecretRedactingJsonReplacer()
+    )
+
+    expect(serialized).not.toContain(LCU_TOKEN)
+    expect(serialized).not.toContain(RIOT_TOKEN)
+    expect(serialized).toContain(`"authToken":"${REDACTED_SECRET}"`)
+    expect(serialized).toContain('"port":12345')
+  })
+})

--- a/src/shared/utils/redact-secrets.ts
+++ b/src/shared/utils/redact-secrets.ts
@@ -1,0 +1,30 @@
+export const REDACTED_SECRET = '<redacted>'
+
+const SENSITIVE_KEY_PATTERN =
+  /^(?:authorization|password|accessToken|authToken|riotClientAuthToken|remotingAuthToken|entitlementsToken|leagueSessionToken|token)$/i
+
+const COMMAND_LINE_TOKEN_PATTERN =
+  /(--(?:remoting-auth-token|riotclient-auth-token)(?:=|\s+))(?:(?:"[^"]*")|(?:'[^']*')|[^\s"']+)/gi
+const AUTHORIZATION_PATTERN = /((?:authorization\s*[:=]\s*)?(?:basic|bearer)\s+)[^\s,"'}]+/gi
+const LOOPBACK_CREDENTIAL_PATTERN =
+  /((?:https?|wss?):\/\/[^:\s/@]+:)[^@\s/]+(@(?:127\.0\.0\.1|localhost)(?::\d+)?)/gi
+const SERIALIZED_SECRET_PATTERN =
+  /((?:"|')?(?:accessToken|authToken|riotClientAuthToken|remotingAuthToken|entitlementsToken|leagueSessionToken|token)(?:"|')?\s*[:=]\s*(?:"|')?)[^\s,"'}]+/gi
+
+export function redactSecretsInString(value: string) {
+  return value
+    .replace(COMMAND_LINE_TOKEN_PATTERN, `$1${REDACTED_SECRET}`)
+    .replace(AUTHORIZATION_PATTERN, `$1${REDACTED_SECRET}`)
+    .replace(LOOPBACK_CREDENTIAL_PATTERN, `$1${REDACTED_SECRET}$2`)
+    .replace(SERIALIZED_SECRET_PATTERN, `$1${REDACTED_SECRET}`)
+}
+
+export function createSecretRedactingJsonReplacer() {
+  return (key: string, value: unknown) => {
+    if (SENSITIVE_KEY_PATTERN.test(key)) {
+      return REDACTED_SECRET
+    }
+
+    return typeof value === 'string' ? redactSecretsInString(value) : value
+  }
+}


### PR DESCRIPTION
## Summary

Completes the existing Apple Silicon macOS port while preserving the Windows implementation.

- Discovers running Riot and League clients through safe Darwin process inspection and validated application paths.
- Launches macOS application bundles and nested executables without shell-interpolated paths.
- Connects and reconnects to the local Riot and LCU HTTPS/WebSocket APIs with scoped certificate handling and redacted credentials.
- Resolves SGP platform routes from Riot's real platform ID, including `EUW1`, so summoner profiles load correctly.
- Adds macOS lifecycle, Dock reopen, menu, tray, deep-link, single-instance, and Electron global-shortcut behavior.
- Exposes unsupported native Win32 behavior through capability gates instead of loading or calling Windows-only code.
- Produces ad-hoc-signed ARM64 app, DMG, and ZIP artifacts while preserving certificate signing and notarization paths.
- Documents macOS development, installation, logging, signing, verified behavior, and limitations.

## Why

The repository already contained a partial Darwin process adapter, installation candidates, launcher support, and macOS packaging. Several runtime imports and native feature paths could still fail on macOS, client discovery and reconnection were incomplete, and the generated package was not yet validated as a usable Apple Silicon application.

## Verification

Run on an Apple Silicon Mac with Node.js 24 and the checked-in Yarn release:

- `yarn install --immutable`
- `yarn typecheck`
- `yarn test` — 90 test files and 441 tests passed
- `yarn build:mac` — ARM64 app, DMG, and ZIP produced
- Packaged app launched through LaunchServices with the real Riot Client and League Client running
- Riot and LCU authenticated probes returned HTTP 200
- Cold player-page reload loaded the EUW summoner profile and captured no HTTP 400 response
- Dock reopen, minimize/restore, close-to-hide, single-instance, and deep-link delivery were exercised in the packaged app
- Strict deep code-signature verification passed
- All 17 packaged Mach-O payloads are ARM64
- Packaged `better-sqlite3` and the Darwin native helper loaded under Electron 41; an in-memory SQLite query passed
- No Win32 native addon, Win32 magic binary, `regedit`, or PE executable is present in the macOS package
- The DMG passed `hdiutil verify`, mounted successfully, and contained the signed app plus the `/Applications` link
- The ZIP passed integrity, extraction, signing, architecture, and native-module checks

## Current limitations

- The local preview is ad-hoc signed and not notarized. Developer ID signing and notarization remain available when credentials are supplied.
- Foreground-process detection, native input hooks, League window placement/resizing, and features that depend on those contracts remain capability-gated on macOS.
- Intel and universal macOS builds are outside this change; the verified target is Apple Silicon.
- A real Windows runtime/package test was not possible on this Mac, although shared TypeScript checks pass and the Windows implementation/resources remain intact.

## Preview artifacts

The fork's [Apple Silicon preview release](https://github.com/bluwimon/LeagueAkari/releases/tag/macos-arm64-preview-1c6766659e52) contains the verified ARM64 DMG and ZIP. These artifacts are ad-hoc signed and intentionally marked as a prerelease.
