### PR TITLE
fix(window-manager): unpack window icon assets

### DIFF
--- a/src/main/shards/window-manager/aux-window/window.ts
+++ b/src/main/shards/window-manager/aux-window/window.ts
@@ -1,5 +1,5 @@
 import { i18next } from '@main/i18n'
-import icon from '@resources/LA_ICON.ico?asset'
+import icon from '@resources/LA_ICON.ico?asset&asarUnpack'
 import { Notification } from 'electron'
 import { compareShallow, computed } from 'mobx'
 import { z } from 'zod'

--- a/src/main/shards/window-manager/cd-timer-window/windows.ts
+++ b/src/main/shards/window-manager/cd-timer-window/windows.ts
@@ -1,7 +1,7 @@
 import { NATIVE_SUPPORT, nativeInput } from '@main/native'
 import { GameClientMain } from '@main/shards/game-client'
 import { AkariIpcError } from '@main/shards/ipc'
-import icon from '@resources/LA_ICON.ico?asset'
+import icon from '@resources/LA_ICON.ico?asset&asarUnpack'
 import { sleep } from '@shared/utils/sleep'
 import { compareShallow, computed } from 'mobx'
 import { z } from 'zod'

--- a/src/main/shards/window-manager/main-window/window.ts
+++ b/src/main/shards/window-manager/main-window/window.ts
@@ -1,4 +1,4 @@
-import icon from '@resources/LA_ICON.ico?asset'
+import icon from '@resources/LA_ICON.ico?asset&asarUnpack'
 import { Event } from 'electron'
 import { compareShallow } from 'mobx'
 import { z } from 'zod'

--- a/src/main/shards/window-manager/ongoing-game-window/window.test.ts
+++ b/src/main/shards/window-manager/ongoing-game-window/window.test.ts
@@ -39,7 +39,7 @@ vi.mock('@main/shards/game-client', () => ({
   }
 }))
 
-vi.mock('@resources/LA_ICON.ico?asset', () => ({
+vi.mock('@resources/LA_ICON.ico?asset&asarUnpack', () => ({
   default: 'akari-icon.ico'
 }))
 

--- a/src/main/shards/window-manager/ongoing-game-window/window.ts
+++ b/src/main/shards/window-manager/ongoing-game-window/window.ts
@@ -1,7 +1,7 @@
 import { is } from '@electron-toolkit/utils'
 import { NATIVE_SUPPORT } from '@main/native'
 import { GameClientMain } from '@main/shards/game-client'
-import icon from '@resources/LA_ICON.ico?asset'
+import icon from '@resources/LA_ICON.ico?asset&asarUnpack'
 import { compareShallow } from 'mobx'
 import { z } from 'zod'
 

--- a/src/main/shards/window-manager/opgg-window/window.ts
+++ b/src/main/shards/window-manager/opgg-window/window.ts
@@ -1,5 +1,5 @@
 import { GameClientMain } from '@main/shards/game-client'
-import icon from '@resources/OPGG_ICON.ico?asset'
+import icon from '@resources/OPGG_ICON.ico?asset&asarUnpack'
 import { compareShallow, computed } from 'mobx'
 import { z } from 'zod'
 


### PR DESCRIPTION
## Summary

- load window `.ico` assets from `app.asar.unpacked` instead of the ASAR virtual path
- apply the fix consistently to the main, auxiliary, OP.GG, ongoing-game, and cooldown-timer windows
- keep the existing window configuration and public contracts unchanged

## Why

`BrowserWindow.icon` is consumed by the native Windows shell. The previous `?asset` imports resolved to paths inside `app.asar` in packaged portable builds, where Windows 11 25H2 can fail to load the icon and fall back to the generic window placeholder. `?asset&asarUnpack` gives the shell a real filesystem path under `app.asar.unpacked`.

## Verification

- `yarn prettier --write` on all changed files
- `yarn typecheck:node`
- `yarn typecheck:web`
- `yarn test` (87 files, 505 tests)
- `yarn electron-vite build`
- `yarn electron-builder --dir --win --config.npmRebuild=false`
- verified `LA_ICON.ico` and `OPGG_ICON.ico` are present in `dist/win-unpacked/resources/app.asar.unpacked/resources/`
- `git diff --check`

Fixes #474