### PR TITLE
feat(met): persist champion id in encounter records

### DIFF
--- a/src/main/shards/ongoing-game/side-effects-controller.ts
+++ b/src/main/shards/ongoing-game/side-effects-controller.ts
@@ -52,7 +52,8 @@ export class OngoingGameSideEffectsController {
               region: leagueClient.state.auth.region,
               rsoPlatformId: leagueClient.state.auth.rsoPlatformId,
               selfPuuid: leagueClient.data.summoner.me.puuid,
-              queueType: state.queryStage.gameInfo.queueType
+              queueType: state.queryStage.gameInfo.queueType,
+              championId: state.championSelections[player] ?? null
             })
 
             logger.info(`Save game info: ${state.queryStage.gameInfo.gameId}`)

--- a/src/main/shards/saved-player/index.ts
+++ b/src/main/shards/saved-player/index.ts
@@ -126,6 +126,7 @@ export class SavedPlayerMain implements IAkariShardInitDispose {
     encounteredGame.selfPuuid = dto.selfPuuid
     encounteredGame.puuid = dto.puuid
     encounteredGame.queueType = dto.queueType || ''
+    encounteredGame.championId = dto.championId ?? null
     encounteredGame.updateAt = new Date()
 
     return this.storage.dataSource.manager.save(encounteredGame)

--- a/src/main/shards/storage/context.ts
+++ b/src/main/shards/storage/context.ts
@@ -3,7 +3,7 @@ import type { MobxUtilsMain } from '../mobx-utils'
 import type { StorageState } from './state'
 
 export const STORAGE_MAIN_NAMESPACE = 'storage-main'
-export const LEAGUE_AKARI_DB_CURRENT_VERSION = 15
+export const LEAGUE_AKARI_DB_CURRENT_VERSION = 16
 export const LEAGUE_AKARI_DB_FILENAME = 'LeagueAkari.db'
 
 export interface StorageMainContext {

--- a/src/main/shards/storage/database-lifecycle.ts
+++ b/src/main/shards/storage/database-lifecycle.ts
@@ -6,6 +6,7 @@ import type { DataSource, QueryRunner } from 'typeorm'
 import { LEAGUE_AKARI_DB_CURRENT_VERSION, type StorageMainContext } from './context'
 import { v10_LA1_2_0initializationUpgrade } from './upgrades/version-10'
 import { v15_LA1_2_2Upgrade } from './upgrades/version-15'
+import { v16_la1_2_3Upgrade } from './upgrades/version-16'
 
 const DATABASE_CORRUPTION_MESSAGES = ['database disk image is malformed', 'file is not a database']
 
@@ -58,7 +59,8 @@ export function isDatabaseCorruptionError(error: unknown) {
 export class StorageDatabaseLifecycle {
   private readonly _upgrades = {
     10: v10_LA1_2_0initializationUpgrade,
-    15: v15_LA1_2_2Upgrade
+    15: v15_LA1_2_2Upgrade,
+    16: v16_la1_2_3Upgrade
   }
 
   private _rebuildOnUpgradeFailedAttempted = false

--- a/src/main/shards/storage/entities/EncounteredGame.ts
+++ b/src/main/shards/storage/entities/EncounteredGame.ts
@@ -47,4 +47,10 @@ export class EncounteredGame {
   @Column({ type: 'varchar', nullable: false })
   @Index('encountered_games_queue_type')
   queueType: string
+
+  /**
+   * 相遇这局中，该玩家使用的英雄。旧记录可能为 null
+   */
+  @Column({ type: 'integer', nullable: true })
+  championId: number | null
 }

--- a/src/main/shards/storage/upgrades/version-16.ts
+++ b/src/main/shards/storage/upgrades/version-16.ts
@@ -1,0 +1,29 @@
+import { QueryRunner, TableColumn } from 'typeorm'
+
+import { EncounteredGame } from '../entities/EncounteredGame'
+
+/**
+ * Version 16 - Add column `championId` to table EncounteredGames
+ */
+export async function v16_la1_2_3Upgrade(queryRunner: QueryRunner) {
+  const encounteredGames = queryRunner.dataSource.getMetadata(EncounteredGame)
+
+  const table = await queryRunner.getTable(encounteredGames.tablePath)
+
+  if (table) {
+    const column = table.findColumnByName('championId')
+
+    if (!column) {
+      await queryRunner.addColumn(
+        table,
+        new TableColumn({
+          name: 'championId',
+          type: 'integer',
+          isNullable: true
+        })
+      )
+    }
+  }
+
+  await queryRunner.query(`UPDATE Metadata SET value = json('16') WHERE key = 'version'`)
+}

--- a/src/renderer-shared/components/ongoing-game-panel/widgets/player-info-card/player-card-tags/tags/met.test.tsx
+++ b/src/renderer-shared/components/ongoing-game-panel/widgets/player-info-card/player-card-tags/tags/met.test.tsx
@@ -109,7 +109,8 @@ function createSavedInfo(overrides: Partial<SavedInfo> = {}): SavedInfo {
           region: 'NA',
           rsoPlatformId: 'NA1',
           queueType: 'RANKED_SOLO_5x5',
-          updateAt: new Date(0)
+          updateAt: new Date(0),
+          championId: 1
         }
       ],
       page: 1,

--- a/src/renderer-shared/components/ongoing-game-panel/widgets/player-info-card/player-card-tags/tags/met.tsx
+++ b/src/renderer-shared/components/ongoing-game-panel/widgets/player-info-card/player-card-tags/tags/met.tsx
@@ -134,6 +134,7 @@ function mergeSavedInfoWithRecentGames(ctx: PlayerCardTagContext): PlayerCardMer
           rsoPlatformId: '',
           updateAt: new Date(gameStats.date),
           queueType: '',
+          championId: gameStats.opponentChampionId,
           gameStats,
           source: 'recent'
         })
@@ -269,12 +270,20 @@ const renderParticipantStats = (
   </div>
 )
 
-const renderMissingGameStatsCells = () => (
+const renderMissingGameStatsCells = (storedChampionId?: number | null) => (
   <>
     <td class={[metTableCellClass, 'text-black/35 dark:text-white/30']}>-</td>
     <td class={[metTableCellClass, 'text-black/35 dark:text-white/30']}>-</td>
     <td class={[metTableCellClass, 'text-black/35 dark:text-white/30']}>-</td>
-    <td class={[metTableCellClass, 'text-black/35 dark:text-white/30']}>-</td>
+    <td class={[metTableCellClass, 'text-black/35 dark:text-white/30']}>
+      {storedChampionId ? (
+        <div class="flex items-center justify-center gap-1">
+          {renderChampionIcon(storedChampionId)}
+        </div>
+      ) : (
+        '-'
+      )}
+    </td>
   </>
 )
 
@@ -283,7 +292,7 @@ const renderEncounteredGameStatsCells = (
   item: PlayerCardEncounteredGame
 ) => {
   if (!item.gameStats) {
-    return renderMissingGameStatsCells()
+    return renderMissingGameStatsCells(item.championId)
   }
 
   const stats = item.gameStats

--- a/src/shared/shards/saved-player/index.ts
+++ b/src/shared/shards/saved-player/index.ts
@@ -51,6 +51,7 @@ export interface EncounteredGame {
   rsoPlatformId: string
   updateAt: Date
   queueType: string
+  championId: number | null
 }
 
 export interface SavedPlayerQueryDto {
@@ -96,6 +97,7 @@ export interface EncounteredGameSaveDto {
   rsoPlatformId: string
   gameId: number
   queueType: string
+  championId?: number | null
 }
 
 export interface EncounteredGameQueryDto {


### PR DESCRIPTION
## 背景
"遇到过"（met）高亮的 popover 之前依赖事后拉取对局历史来显示"哪天用了哪个英雄"。
当对局过旧/战绩拉不到时，英雄和日期会显示为 `-`。

## 改动
- `EncounteredGame` 实体及 DB 迁移 v16 新增 `championId` 字段
- 游戏结束（`EndOfGame`）时，把本局每位玩家使用的英雄直接从 `state.championSelections` 写入相遇记录
- met 标签 popover 在拉不到战绩时，回退到记录中的 `championId` 展示对方英雄图标

这样无论战绩是否可得，排到同一批人时都能显示"相遇日期 + 当天所用英雄"。

## 验证
- `typecheck:node` / `typecheck:web` 通过
- `met.test.tsx` 7 个用例通过
- 本地 dev 启动后确认迁移 `Executing => version 16 migration` -> `All database migrations completed`