### PR TITLE
refactor(network): add Electron Session-based HTTP transport

### DIFF
--- a/src/main/bootstrap/index.ts
+++ b/src/main/bootstrap/index.ts
@@ -12,6 +12,7 @@ import { AutoSelectMain } from '@main/shards/auto-select'
 import { ChampionDataMain } from '@main/shards/champion-data'
 import { ClientInstallationMain } from '@main/shards/client-installation'
 import { ConfigMigrateMain } from '@main/shards/config-migrate'
+import { ExternalHttpMain } from '@main/shards/external-http'
 import { ExtraAssetsMain } from '@main/shards/extra-assets'
 import { FeatureGatingMain } from '@main/shards/feature-gating'
 import { GameClientMain } from '@main/shards/game-client'
@@ -314,6 +315,7 @@ export function bootstrap() {
 
     // connection & data provider shards
     manager.use(ConfigMigrateMain)
+    manager.use(ExternalHttpMain)
     manager.use(SettingFactoryMain)
     manager.use(StorageMain)
 

--- a/src/main/shards/app-common/state.ts
+++ b/src/main/shards/app-common/state.ts
@@ -114,7 +114,7 @@ export class AppCommonSettings {
     this.theme = s
   }
 
-  setHttpProxy(s: { strategy: 'force' | 'disable'; port: number; host: string }) {
+  setHttpProxy(s: { strategy: 'auto' | 'force' | 'disable'; port: number; host: string }) {
     this.httpProxy = s
   }
 

--- a/src/main/shards/champion-data/index.ts
+++ b/src/main/shards/champion-data/index.ts
@@ -2,11 +2,11 @@ import { IAkariShardInitDispose, Shard } from '@shared/akari-shard'
 import type { ChampionDataPreferences } from '@shared/data-adapter/champion-data'
 import { OpggHttpApiAxiosHelper } from '@shared/http-api-axios-helper/opgg'
 import { Qq101HttpApiAxiosHelper } from '@shared/http-api-axios-helper/qq101'
-import axios, { type AxiosInstance } from 'axios'
+import type { AxiosInstance } from 'axios'
 import type { AxiosRetry } from 'axios-retry'
 import { z } from 'zod'
 
-import { AppCommonMain } from '../app-common'
+import { ExternalHttpMain } from '../external-http'
 import { FeatureGatingMain } from '../feature-gating'
 import { AkariIpcMain } from '../ipc'
 import { type AkariLogger, LoggerFactoryMain } from '../logger-factory'
@@ -51,7 +51,7 @@ export class ChampionDataMain implements IAkariShardInitDispose {
   private readonly _ipcHandlers: ChampionDataIpcHandlers
 
   constructor(
-    private readonly _appCommon: AppCommonMain,
+    private readonly _externalHttp: ExternalHttpMain,
     private readonly _featureGating: FeatureGatingMain,
     private readonly _ipc: AkariIpcMain,
     loggerFactory: LoggerFactoryMain,
@@ -103,7 +103,6 @@ export class ChampionDataMain implements IAkariShardInitDispose {
       'lastFallbackReason'
     ])
     this._watchAvailability()
-    this._watchHttpProxy()
     this._ipcHandlers.register()
   }
 
@@ -127,7 +126,7 @@ export class ChampionDataMain implements IAkariShardInitDispose {
   }
 
   private _createHttpClient(headers?: Record<string, string>) {
-    const client = axios.create({ timeout: 8_000, headers })
+    const client = this._externalHttp.createAxiosClient({ timeout: 8_000, headers })
     axiosRetry(client, {
       retries: 1,
       shouldResetTimeout: true,
@@ -162,24 +161,6 @@ export class ChampionDataMain implements IAkariShardInitDispose {
           preferredSource,
           sources: { opgg: { enabled: opgg }, qq101: { enabled: qq101 } }
         })
-      },
-      { fireImmediately: true }
-    )
-  }
-
-  private _watchHttpProxy() {
-    this._mobxUtils.reaction(
-      () => this._appCommon.settings.httpProxy,
-      (httpProxy) => {
-        for (const client of [this._opggHttpClient, this._qq101HttpClient]) {
-          if (httpProxy.strategy === 'force') {
-            client.defaults.proxy = { host: httpProxy.host, port: httpProxy.port }
-          } else if (httpProxy.strategy === 'disable') {
-            client.defaults.proxy = false
-          } else {
-            client.defaults.proxy = undefined
-          }
-        }
       },
       { fireImmediately: true }
     )

--- a/src/main/shards/external-http/axios-client.test.ts
+++ b/src/main/shards/external-http/axios-client.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createExternalHttpAxiosClient } from './axios-client'
+import type { ExternalHttpSession } from './context'
+
+function jsonResponse(data: unknown) {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' }
+  })
+}
+
+describe('createExternalHttpAxiosClient', () => {
+  it('waits for proxy configuration and uses the Electron session fetch', async () => {
+    let resolveConfiguration!: () => void
+    const configured = new Promise<void>((resolve) => {
+      resolveConfiguration = resolve
+    })
+    const fetch = vi.fn(async (_input: URL | Request | string, _init?: RequestInit) =>
+      jsonResponse({ ok: true })
+    )
+    const client = createExternalHttpAxiosClient(
+      { fetch } as unknown as ExternalHttpSession,
+      () => configured,
+      {
+        baseURL: 'https://example.com',
+        headers: { 'X-Akari-Test': 'yes' }
+      }
+    )
+
+    const pending = client.get('/data', { params: { mode: 'ranked' } })
+    await Promise.resolve()
+    expect(fetch).not.toHaveBeenCalled()
+
+    resolveConfiguration()
+    await expect(pending).resolves.toMatchObject({ data: { ok: true } })
+
+    const request = fetch.mock.calls[0][0] as Request
+    expect(request.url).toBe('https://example.com/data?mode=ranked')
+    expect(request.headers.get('X-Akari-Test')).toBe('yes')
+  })
+
+  it('forwards cancellation to the Electron request signal', async () => {
+    let requestSignal: AbortSignal | undefined
+    const fetch = vi.fn((input: URL | Request | string, _init?: RequestInit) => {
+      requestSignal = (input as Request).signal
+      return new Promise<Response>((_, reject) => {
+        requestSignal?.addEventListener('abort', () => reject(requestSignal?.reason), {
+          once: true
+        })
+      })
+    })
+    const client = createExternalHttpAxiosClient(
+      { fetch } as unknown as ExternalHttpSession,
+      async () => undefined,
+      { baseURL: 'https://example.com' }
+    )
+    const controller = new AbortController()
+
+    const pending = client.get('/slow', { signal: controller.signal })
+    await vi.waitFor(() => expect(requestSignal).toBeDefined())
+    controller.abort()
+
+    await expect(pending).rejects.toMatchObject({ code: 'ERR_CANCELED' })
+    expect(requestSignal?.aborted).toBe(true)
+  })
+})

--- a/src/main/shards/external-http/axios-client.test.ts
+++ b/src/main/shards/external-http/axios-client.test.ts
@@ -1,7 +1,10 @@
+import type { AxiosRetry } from 'axios-retry'
 import { describe, expect, it, vi } from 'vitest'
 
 import { createExternalHttpAxiosClient } from './axios-client'
 import type { ExternalHttpSession } from './context'
+
+const axiosRetry = require('axios-retry').default as AxiosRetry
 
 function jsonResponse(data: unknown) {
   return new Response(JSON.stringify(data), {
@@ -63,5 +66,27 @@ describe('createExternalHttpAxiosClient', () => {
 
     await expect(pending).rejects.toMatchObject({ code: 'ERR_CANCELED' })
     expect(requestSignal?.aborted).toBe(true)
+  })
+
+  it('remains compatible with the champion-data retry policy', async () => {
+    const fetch = vi
+      .fn<ExternalHttpSession['fetch']>()
+      .mockRejectedValueOnce(new TypeError('network failure'))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }))
+    const client = createExternalHttpAxiosClient(
+      { fetch } as unknown as ExternalHttpSession,
+      async () => undefined,
+      { baseURL: 'https://example.com', timeout: 8_000 }
+    )
+    axiosRetry(client, {
+      retries: 1,
+      shouldResetTimeout: true,
+      retryDelay: () => 0,
+      retryCondition: axiosRetry.isNetworkOrIdempotentRequestError
+    })
+
+    await expect(client.get('/retry')).resolves.toMatchObject({ data: { ok: true } })
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(client.defaults.timeout).toBe(8_000)
   })
 })

--- a/src/main/shards/external-http/axios-client.ts
+++ b/src/main/shards/external-http/axios-client.ts
@@ -1,0 +1,25 @@
+import axios, { type AxiosInstance, type CreateAxiosDefaults } from 'axios'
+
+import type { ExternalHttpSession } from './context'
+
+type AxiosFetch = NonNullable<NonNullable<CreateAxiosDefaults['env']>['fetch']>
+
+export function createExternalHttpAxiosClient(
+  electronSession: ExternalHttpSession,
+  waitUntilConfigured: () => Promise<void>,
+  defaults: CreateAxiosDefaults = {}
+): AxiosInstance {
+  const electronFetch: AxiosFetch = async (input, init) => {
+    await waitUntilConfigured()
+    return electronSession.fetch(input instanceof URL ? input.toString() : input, init)
+  }
+
+  return axios.create({
+    ...defaults,
+    adapter: 'fetch',
+    env: {
+      ...defaults.env,
+      fetch: electronFetch
+    }
+  })
+}

--- a/src/main/shards/external-http/context.ts
+++ b/src/main/shards/external-http/context.ts
@@ -1,0 +1,21 @@
+import type { Session } from 'electron'
+
+import type { AppCommonMain } from '../app-common'
+import type { AkariLogger } from '../logger-factory'
+import type { MobxUtilsMain } from '../mobx-utils'
+
+export const EXTERNAL_HTTP_MAIN_NAMESPACE = 'external-http-main'
+export const EXTERNAL_HTTP_SESSION_PARTITION = 'external-http'
+
+export type ExternalHttpSession = Pick<
+  Session,
+  'fetch' | 'setProxy' | 'resolveProxy' | 'closeAllConnections'
+>
+
+export interface ExternalHttpMainContext {
+  namespace: string
+  appCommon: AppCommonMain
+  logger: AkariLogger
+  mobxUtils: MobxUtilsMain
+  electronSession: ExternalHttpSession
+}

--- a/src/main/shards/external-http/index.ts
+++ b/src/main/shards/external-http/index.ts
@@ -1,0 +1,64 @@
+import { IAkariShardInitDispose, Shard } from '@shared/akari-shard'
+import type { CreateAxiosDefaults } from 'axios'
+import { session } from 'electron'
+
+import { AppCommonMain } from '../app-common'
+import { type AkariLogger, LoggerFactoryMain } from '../logger-factory'
+import { MobxUtilsMain } from '../mobx-utils'
+import { createExternalHttpAxiosClient } from './axios-client'
+import {
+  EXTERNAL_HTTP_MAIN_NAMESPACE,
+  EXTERNAL_HTTP_SESSION_PARTITION,
+  type ExternalHttpMainContext
+} from './context'
+import { ExternalHttpProxyController } from './proxy-controller'
+
+@Shard(ExternalHttpMain.id)
+export class ExternalHttpMain implements IAkariShardInitDispose {
+  static id = EXTERNAL_HTTP_MAIN_NAMESPACE
+
+  private readonly _logger: AkariLogger
+  private readonly _context: ExternalHttpMainContext
+  private readonly _proxyController: ExternalHttpProxyController
+
+  constructor(
+    private readonly _appCommon: AppCommonMain,
+    loggerFactory: LoggerFactoryMain,
+    private readonly _mobxUtils: MobxUtilsMain
+  ) {
+    this._logger = loggerFactory.create(ExternalHttpMain.id)
+    this._context = {
+      namespace: ExternalHttpMain.id,
+      appCommon: this._appCommon,
+      logger: this._logger,
+      mobxUtils: this._mobxUtils,
+      electronSession: session.fromPartition(EXTERNAL_HTTP_SESSION_PARTITION, { cache: false })
+    }
+    this._proxyController = new ExternalHttpProxyController(this._context)
+  }
+
+  createAxiosClient(defaults: CreateAxiosDefaults = {}) {
+    return createExternalHttpAxiosClient(
+      this._context.electronSession,
+      () => this._proxyController.waitUntilConfigured(),
+      defaults
+    )
+  }
+
+  resolveProxy(url: string) {
+    return this._context.electronSession.resolveProxy(url)
+  }
+
+  async onInit() {
+    this._proxyController.start()
+  }
+
+  async onDispose() {
+    this._proxyController.dispose()
+    try {
+      await this._context.electronSession.closeAllConnections()
+    } catch (error) {
+      this._logger.warn('Failed to close external HTTP connections during disposal', error)
+    }
+  }
+}

--- a/src/main/shards/external-http/proxy-controller.test.ts
+++ b/src/main/shards/external-http/proxy-controller.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { ExternalHttpMainContext } from './context'
+import { ExternalHttpProxyController, resolveExternalHttpProxyConfig } from './proxy-controller'
+
+describe('resolveExternalHttpProxyConfig', () => {
+  it('maps Akari proxy strategies to Electron proxy modes', () => {
+    expect(
+      resolveExternalHttpProxyConfig({ strategy: 'auto', host: '127.0.0.1', port: 7890 })
+    ).toEqual({ mode: 'system' })
+    expect(
+      resolveExternalHttpProxyConfig({ strategy: 'disable', host: '127.0.0.1', port: 7890 })
+    ).toEqual({ mode: 'direct' })
+    expect(
+      resolveExternalHttpProxyConfig({ strategy: 'force', host: '127.0.0.1', port: 7890 })
+    ).toEqual({ mode: 'fixed_servers', proxyRules: '127.0.0.1:7890' })
+  })
+})
+
+describe('ExternalHttpProxyController', () => {
+  it('configures the initial proxy without closing an unused connection pool', async () => {
+    const setting = { strategy: 'disable' as const, host: '127.0.0.1', port: 7890 }
+    const dispose = vi.fn()
+    const setProxy = vi.fn().mockResolvedValue(undefined)
+    const closeAllConnections = vi.fn().mockResolvedValue(undefined)
+    const context = {
+      appCommon: { settings: { httpProxy: setting } },
+      logger: { warn: vi.fn() },
+      electronSession: { setProxy, closeAllConnections },
+      mobxUtils: {
+        reaction: vi.fn((expression, effect) => {
+          effect(expression())
+          return dispose
+        })
+      }
+    } as unknown as ExternalHttpMainContext
+    const controller = new ExternalHttpProxyController(context)
+
+    controller.start()
+    await controller.waitUntilConfigured()
+
+    expect(setProxy).toHaveBeenCalledWith({ mode: 'direct' })
+    expect(closeAllConnections).not.toHaveBeenCalled()
+    controller.dispose()
+    expect(dispose).toHaveBeenCalledOnce()
+  })
+
+  it('serializes proxy changes and closes connections after reconfiguration', async () => {
+    const setting = { strategy: 'disable' as const, host: '127.0.0.1', port: 7890 }
+    let updateProxy!: (setting: {
+      strategy: 'auto' | 'force' | 'disable'
+      host: string
+      port: number
+    }) => void
+    let finishInitialConfiguration!: () => void
+    const initialConfiguration = new Promise<void>((resolve) => {
+      finishInitialConfiguration = resolve
+    })
+    const setProxy = vi
+      .fn()
+      .mockReturnValueOnce(initialConfiguration)
+      .mockResolvedValueOnce(undefined)
+    const closeAllConnections = vi.fn().mockResolvedValue(undefined)
+    const context = {
+      appCommon: { settings: { httpProxy: setting } },
+      logger: { warn: vi.fn() },
+      electronSession: { setProxy, closeAllConnections },
+      mobxUtils: {
+        reaction: vi.fn((expression, effect) => {
+          effect(expression())
+          updateProxy = effect
+          return vi.fn()
+        })
+      }
+    } as unknown as ExternalHttpMainContext
+    const controller = new ExternalHttpProxyController(context)
+
+    controller.start()
+    await vi.waitFor(() => expect(setProxy).toHaveBeenCalledTimes(1))
+    updateProxy({ strategy: 'force', host: 'localhost', port: 1080 })
+    await Promise.resolve()
+    expect(setProxy).toHaveBeenCalledTimes(1)
+
+    finishInitialConfiguration()
+    await controller.waitUntilConfigured()
+
+    expect(setProxy).toHaveBeenNthCalledWith(2, {
+      mode: 'fixed_servers',
+      proxyRules: 'localhost:1080'
+    })
+    expect(closeAllConnections).toHaveBeenCalledOnce()
+  })
+
+  it('keeps startup alive when proxy configuration fails and blocks requests', async () => {
+    const error = new Error('proxy failed')
+    const logger = { warn: vi.fn() }
+    const context = {
+      appCommon: {
+        settings: {
+          httpProxy: { strategy: 'auto', host: '127.0.0.1', port: 7890 }
+        }
+      },
+      logger,
+      electronSession: {
+        setProxy: vi.fn().mockRejectedValue(error),
+        closeAllConnections: vi.fn()
+      },
+      mobxUtils: {
+        reaction: vi.fn((expression, effect) => {
+          effect(expression())
+          return vi.fn()
+        })
+      }
+    } as unknown as ExternalHttpMainContext
+    const controller = new ExternalHttpProxyController(context)
+
+    expect(() => controller.start()).not.toThrow()
+    await expect(controller.waitUntilConfigured()).rejects.toThrow('proxy failed')
+    await vi.waitFor(() => expect(logger.warn).toHaveBeenCalled())
+  })
+})

--- a/src/main/shards/external-http/proxy-controller.ts
+++ b/src/main/shards/external-http/proxy-controller.ts
@@ -1,0 +1,78 @@
+import { formatError } from '@shared/utils/errors'
+import type { ProxyConfig } from 'electron'
+
+import type { ExternalHttpMainContext } from './context'
+
+type HttpProxySetting = ExternalHttpMainContext['appCommon']['settings']['httpProxy']
+
+export function resolveExternalHttpProxyConfig(setting: HttpProxySetting): ProxyConfig {
+  switch (setting.strategy) {
+    case 'auto':
+      return { mode: 'system' }
+    case 'force':
+      return {
+        mode: 'fixed_servers',
+        proxyRules: `${setting.host}:${setting.port}`
+      }
+    case 'disable':
+      return { mode: 'direct' }
+  }
+}
+
+export class ExternalHttpProxyController {
+  private _disposeReaction: (() => void) | null = null
+  private _configurationQueue: Promise<void> = Promise.resolve()
+  private _latestConfiguration: Promise<void> = Promise.resolve()
+  private _hasAppliedConfiguration = false
+
+  constructor(private readonly _context: ExternalHttpMainContext) {}
+
+  start() {
+    if (this._disposeReaction) return
+
+    this._disposeReaction = this._context.mobxUtils.reaction(
+      () => this._context.appCommon.settings.httpProxy,
+      (setting) => this._scheduleConfiguration(setting),
+      { fireImmediately: true }
+    )
+  }
+
+  waitUntilConfigured() {
+    return this._latestConfiguration
+  }
+
+  dispose() {
+    this._disposeReaction?.()
+    this._disposeReaction = null
+  }
+
+  private _scheduleConfiguration(setting: HttpProxySetting) {
+    const config = resolveExternalHttpProxyConfig(setting)
+    const task = this._configurationQueue
+      .catch(() => undefined)
+      .then(() => this._applyConfiguration(config))
+
+    this._configurationQueue = task
+    this._latestConfiguration = task
+    void task.catch((error) => {
+      this._context.logger.warn('Failed to configure external HTTP proxy', formatError(error))
+    })
+  }
+
+  private async _applyConfiguration(config: ProxyConfig) {
+    await this._context.electronSession.setProxy(config)
+
+    if (this._hasAppliedConfiguration) {
+      try {
+        await this._context.electronSession.closeAllConnections()
+      } catch (error) {
+        this._context.logger.warn(
+          'Failed to close external HTTP connections after proxy change',
+          formatError(error)
+        )
+      }
+    }
+
+    this._hasAppliedConfiguration = true
+  }
+}

--- a/src/renderer/src-main-window/components/settings-modal/AppSettings.vue
+++ b/src/renderer/src-main-window/components/settings-modal/AppSettings.vue
@@ -708,10 +708,10 @@ const handleUninstallApp = () => {
 
 const httpProxyStrategies = computed(() => {
   return [
-    // {
-    //   label: t('settings.app.misc.httpProxy.strategy.options.auto'),
-    //   value: 'auto'
-    // },
+    {
+      label: t('settings.app.misc.httpProxy.strategy.options.auto'),
+      value: 'auto'
+    },
     {
       label: t('settings.app.misc.httpProxy.strategy.options.disable'),
       value: 'disable'

--- a/src/shared/i18n/en/renderer/settings.yaml
+++ b/src/shared/i18n/en/renderer/settings.yaml
@@ -150,7 +150,7 @@ settings:
       httpProxy:
         strategy:
           label: HTTP Proxy
-          description: Set the HTTP proxy. All network requests except LCU HTTP will be routed through this proxy
+          description: Configure the proxy for external HTTP requests. Follow System currently applies to OP.GG and 101; local LCU requests are unaffected
           options:
             force: Use Proxy
             auto: Auto

--- a/src/shared/i18n/zh-CN/renderer/settings.yaml
+++ b/src/shared/i18n/zh-CN/renderer/settings.yaml
@@ -150,7 +150,7 @@ settings:
       httpProxy:
         strategy:
           label: HTTP 代理
-          description: 设置 HTTP 代理，除 LCU HTTP 之外的所有网络请求都将通过该代理
+          description: 设置应用外部 HTTP 请求的代理。跟随系统目前用于 OP.GG 和 101；LCU 本地请求不受影响
           options:
             force: 使用代理
             auto: 跟随系统


### PR DESCRIPTION
## Summary

- Add a main-process external HTTP transport based on Electron Session.
- Support system proxy, direct connection, and manually configured proxy modes.
- Migrate Champion Data requests to the unified transport.
- Restore the system proxy option in settings.
- Preserve the existing timeout, retry, cancellation, and data-source isolation behavior.
- Keep the default proxy strategy unchanged, so existing users are not affected unless they change the setting.

## Testing

- Windows type checking and production build passed.
- Windows package build passed.
- Full test suite passed: 101 test files, 575 tests.
- External HTTP and Champion Data tests passed in three consecutive runs.
- Verified OP.GG and 101 requests with:
  - direct connection
  - system proxy enabled
  - system proxy disabled
  - manually configured proxy
- Verified timeout, single retry, IPC cancellation, application restart, and settings persistence.
- Verified the packaged Windows application with real OP.GG and 101 responses.
