### PR TITLE
fix(app-common): make Windows administrator relaunch reliable

### DIFF
--- a/src/main/administrator-relaunch/index.test.ts
+++ b/src/main/administrator-relaunch/index.test.ts
@@ -1,0 +1,71 @@
+import { app } from 'electron'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { getAdministratorRelaunchParentPid, waitForAdministratorRelaunchParent } from '.'
+
+vi.mock('electron', () => ({ app: { commandLine: { removeSwitch: vi.fn() } } }))
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('administrator restart handoff', () => {
+  it('only accepts a positive Windows parent PID, never a signal process group or self', () => {
+    expect(getAdministratorRelaunchParentPid(['--akari-administrator-relaunch=123'], 'win32')).toBe(
+      123
+    )
+    for (const value of ['0', '-1', '1.2', 'NaN', '4294967296', String(process.pid)]) {
+      expect(
+        getAdministratorRelaunchParentPid([`--akari-administrator-relaunch=${value}`], 'win32')
+      ).toBeNull()
+    }
+    expect(
+      getAdministratorRelaunchParentPid(['--akari-administrator-relaunch=123'], 'darwin')
+    ).toBeNull()
+    expect(getAdministratorRelaunchParentPid([], 'win32')).toBeNull()
+  })
+
+  it('does not proceed until the old PID exits, and removes the one-shot flag', () => {
+    const kill = vi
+      .fn()
+      .mockReturnValueOnce(true)
+      .mockImplementation(() => {
+        throw Object.assign(new Error('exited'), { code: 'ESRCH' })
+      })
+    vi.stubGlobal('process', {
+      ...process,
+      platform: 'win32',
+      argv: ['app', '--akari-administrator-relaunch=123'],
+      kill
+    })
+    vi.spyOn(Atomics, 'wait').mockReturnValue('timed-out')
+    waitForAdministratorRelaunchParent(123)
+    expect(kill.mock.calls).toEqual([
+      [123, 0],
+      [123, 0]
+    ])
+    expect(process.argv).toEqual(['app'])
+    expect(app.commandLine.removeSwitch).toHaveBeenCalledWith('akari-administrator-relaunch')
+  })
+
+  it.each(['timeout', 'permission'])(
+    'fails boundedly on %s instead of starting two database owners',
+    (reason) => {
+      const kill = vi.fn(() => {
+        if (reason === 'permission') throw Object.assign(new Error('denied'), { code: 'EPERM' })
+        return true
+      })
+      vi.stubGlobal('process', { ...process, platform: 'win32', argv: [], kill })
+      expect(() => waitForAdministratorRelaunchParent(123, 0)).toThrow()
+      expect(kill).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it('does not wait or alter arguments for normal startup or macOS', () => {
+    const kill = vi.fn()
+    vi.stubGlobal('process', { ...process, platform: 'darwin', kill })
+    waitForAdministratorRelaunchParent(123)
+    waitForAdministratorRelaunchParent(null)
+    expect(kill).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/administrator-relaunch/index.ts
+++ b/src/main/administrator-relaunch/index.ts
@@ -1,0 +1,67 @@
+import { app } from 'electron'
+
+export const ADMINISTRATOR_RELAUNCH_SWITCH = 'akari-administrator-relaunch'
+
+export function supportsAdministratorRelaunch(platform = process.platform) {
+  return platform === 'win32'
+}
+
+export function getAdministratorRelaunchParentPid(
+  argv = process.argv,
+  platform = process.platform
+) {
+  if (!supportsAdministratorRelaunch(platform)) {
+    return null
+  }
+
+  const value = argv.find((arg) => arg.startsWith(`--${ADMINISTRATOR_RELAUNCH_SWITCH}=`))
+  const pidText = value?.slice(ADMINISTRATOR_RELAUNCH_SWITCH.length + 3)
+  if (!pidText || !/^[1-9]\d*$/.test(pidText)) {
+    return null
+  }
+
+  const pid = Number(pidText)
+  return Number.isSafeInteger(pid) && pid <= 0xffffffff && pid !== process.pid ? pid : null
+}
+
+const administratorRelaunchParentPid = getAdministratorRelaunchParentPid()
+
+export function wasRelaunchedAsAdministrator() {
+  return administratorRelaunchParentPid !== null
+}
+
+/** Wait before Electron's first tick: bootstrap must still register schemes and GPU flags pre-ready. */
+export function waitForAdministratorRelaunchParent(
+  parentPid = administratorRelaunchParentPid,
+  timeoutMs = 30_000
+) {
+  if (parentPid === null || !supportsAdministratorRelaunch()) {
+    return
+  }
+
+  // This is a one-shot handoff, not an argument for future ordinary app.relaunch() calls.
+  app.commandLine.removeSwitch(ADMINISTRATOR_RELAUNCH_SWITCH)
+  process.argv = process.argv.filter(
+    (arg) => !arg.startsWith(`--${ADMINISTRATOR_RELAUNCH_SWITCH}=`)
+  )
+
+  const deadline = Date.now() + timeoutMs
+  const sleepArray = new Int32Array(new SharedArrayBuffer(4))
+  while (true) {
+    try {
+      process.kill(parentPid, 0)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ESRCH') {
+        return
+      }
+      throw error
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error(
+        'The previous League Akari process has not exited. Please close it and retry.'
+      )
+    }
+    Atomics.wait(sleepArray, 0, 0, 50)
+  }
+}

--- a/src/main/administrator-relaunch/startup.test.ts
+++ b/src/main/administrator-relaunch/startup.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  wait: vi.fn(),
+  lock: vi.fn(),
+  bootstrap: vi.fn(),
+  quit: vi.fn(),
+  exit: vi.fn(),
+  showErrorBox: vi.fn()
+}))
+vi.mock('@main/administrator-relaunch', () => ({ waitForAdministratorRelaunchParent: mocks.wait }))
+vi.mock('../bootstrap', () => ({ bootstrap: mocks.bootstrap }))
+vi.mock('electron', () => ({
+  app: {
+    setAppUserModelId: vi.fn(),
+    requestSingleInstanceLock: mocks.lock,
+    quit: mocks.quit,
+    exit: mocks.exit
+  },
+  dialog: { showErrorBox: mocks.showErrorBox }
+}))
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.resetAllMocks()
+  mocks.lock.mockReturnValue(true)
+})
+
+it('waits for the predecessor before taking the lock and bootstrapping the app', async () => {
+  await import('../main.js')
+  expect(mocks.wait).toHaveBeenCalledBefore(mocks.lock)
+  expect(mocks.lock).toHaveBeenCalledBefore(mocks.bootstrap)
+})
+
+it('does not initialize another app or open its database after a failed handoff', async () => {
+  mocks.wait.mockImplementation(() => {
+    throw new Error('predecessor did not exit')
+  })
+  await import('../main.js')
+  expect(mocks.showErrorBox).toHaveBeenCalledTimes(1)
+  expect(mocks.exit).toHaveBeenCalledWith(1)
+  expect(mocks.lock).not.toHaveBeenCalled()
+  expect(mocks.bootstrap).not.toHaveBeenCalled()
+})
+
+it('preserves the normal single-instance rejection path', async () => {
+  mocks.lock.mockReturnValue(false)
+  await import('../main.js')
+  expect(mocks.quit).toHaveBeenCalledTimes(1)
+  expect(mocks.bootstrap).not.toHaveBeenCalled()
+})

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,17 +1,28 @@
 import 'reflect-metadata'
 
-import { app } from 'electron'
+import { app, dialog } from 'electron'
 
+import { waitForAdministratorRelaunchParent } from './administrator-relaunch'
 import { bootstrap } from './bootstrap'
 
 if (process.platform === 'win32') {
   app.setAppUserModelId('sugar.cocoa.league-akari')
 }
 
-const gotTheLock = app.requestSingleInstanceLock()
+function start() {
+  try {
+    waitForAdministratorRelaunchParent()
+  } catch (error) {
+    dialog.showErrorBox('League Akari: administrator relaunch failed', String(error))
+    app.exit(1)
+    return
+  }
 
-if (gotTheLock) {
-  bootstrap()
-} else {
-  app.quit()
+  if (app.requestSingleInstanceLock()) {
+    bootstrap()
+  } else {
+    app.quit()
+  }
 }
+
+start()

--- a/src/main/shards/app-common/administrator-relaunch-executor.test.ts
+++ b/src/main/shards/app-common/administrator-relaunch-executor.test.ts
@@ -1,0 +1,92 @@
+import { app } from 'electron'
+import { execFile } from 'node:child_process'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AdministratorRelaunchExecutor } from './administrator-relaunch-executor'
+
+vi.mock('@resources/elevate.exe?asset&asarUnpack', () => ({
+  default: 'C:\\测试 & %TEMP%\\elevate.exe'
+}))
+vi.mock('electron', () => ({ app: { getAppPath: () => 'C:\\开发 测试\\Akari' } }))
+vi.mock('node:child_process', () => ({ execFile: vi.fn() }))
+
+const quit = vi.fn()
+const logger = { info: vi.fn(), warn: vi.fn() }
+const makeExecutor = () =>
+  new AdministratorRelaunchExecutor({ shared: { global: { quit } }, logger } as any)
+
+beforeEach(() => {
+  vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+  vi.stubGlobal('process', process)
+})
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.clearAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('administrator relaunch', () => {
+  it('keeps the old app alive during UAC and coalesces repeated requests, then quits normally', async () => {
+    let complete!: (error: Error | null) => void
+    vi.mocked(execFile).mockImplementation((...args: any[]) => {
+      complete = args.at(-1)
+      return {} as any
+    })
+    const executor = makeExecutor()
+    const first = executor.relaunch()
+    const second = executor.relaunch()
+    expect(first).toBe(second)
+    expect(execFile).toHaveBeenCalledTimes(1)
+    expect(quit).not.toHaveBeenCalled()
+    expect(execFile).toHaveBeenCalledWith(
+      'C:\\测试 & %TEMP%\\elevate.exe',
+      [process.execPath, `--akari-administrator-relaunch=${process.pid}`],
+      { windowsHide: true },
+      expect.any(Function)
+    )
+    complete(null)
+    await first
+    await executor.relaunch()
+    expect(quit).toHaveBeenCalledTimes(1)
+    expect(execFile).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(['UAC cancelled: 1223', 'ENOENT', 'Access denied'])(
+    '%s preserves the original app and permits retry',
+    async (reason) => {
+      vi.mocked(execFile).mockImplementation((...args: any[]) => {
+        args.at(-1)(new Error(reason))
+        return {} as any
+      })
+      const executor = makeExecutor()
+      await expect(executor.relaunch()).rejects.toThrow(reason)
+      expect(quit).not.toHaveBeenCalled()
+      await expect(executor.relaunch()).rejects.toThrow(reason)
+      expect(execFile).toHaveBeenCalledTimes(2)
+    }
+  )
+
+  it.each(['darwin', 'linux'] as const)(
+    'rejects direct calls on %s without starting a process or quitting',
+    async (platform) => {
+      vi.spyOn(process, 'platform', 'get').mockReturnValue(platform)
+      await expect(makeExecutor().relaunch()).rejects.toThrow('only supported on Windows')
+      expect(execFile).not.toHaveBeenCalled()
+      expect(quit).not.toHaveBeenCalled()
+    }
+  )
+
+  it('preserves the development app path instead of starting an empty Electron instance', async () => {
+    vi.stubGlobal('process', { ...process, defaultApp: true })
+    vi.mocked(execFile).mockImplementation((...args: any[]) => {
+      args.at(-1)(null)
+      return {} as any
+    })
+    await makeExecutor().relaunch()
+    expect(vi.mocked(execFile).mock.calls[0][1]).toEqual([
+      process.execPath,
+      `"${app.getAppPath()}"`,
+      `--akari-administrator-relaunch=${process.pid}`
+    ])
+  })
+})

--- a/src/main/shards/app-common/administrator-relaunch-executor.ts
+++ b/src/main/shards/app-common/administrator-relaunch-executor.ts
@@ -1,0 +1,50 @@
+import {
+  ADMINISTRATOR_RELAUNCH_SWITCH,
+  supportsAdministratorRelaunch
+} from '@main/administrator-relaunch'
+import elevateExecutablePath from '@resources/elevate.exe?asset&asarUnpack'
+import { app } from 'electron'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+import type { AppCommonMainContext } from './context'
+
+const execFileAsync = promisify(execFile)
+
+export class AdministratorRelaunchExecutor {
+  private _pending: Promise<void> | null = null
+
+  constructor(private readonly _context: AppCommonMainContext) {}
+
+  relaunch(): Promise<void> {
+    if (!supportsAdministratorRelaunch()) {
+      return Promise.reject(new Error('Administrator relaunch is only supported on Windows'))
+    }
+
+    if (!this._pending) {
+      this._pending = this._launch().catch((error) => {
+        this._pending = null
+        this._context.logger.warn('Administrator relaunch failed or was cancelled', error)
+        throw error
+      })
+    }
+    return this._pending
+  }
+
+  private async _launch() {
+    // elevate.exe joins target arguments verbatim, so the development app path needs its own quotes.
+    const args = process.defaultApp ? [`"${app.getAppPath()}"`] : []
+    args.push(`--${ADMINISTRATOR_RELAUNCH_SWITCH}=${process.pid}`)
+
+    this._context.logger.info('Requesting administrator relaunch')
+    // Avoid cmd.exe expansion of %, &, ^ and other characters in installation paths.
+    await execFileAsync(elevateExecutablePath, [process.execPath, ...args], {
+      windowsHide: true
+    })
+
+    this._context.logger.info('Administrator launch accepted; shutting down the previous instance')
+    // Flush settings and dispose shards. The new process waits for this process to exit before
+    // acquiring the single-instance lock or opening the database.
+    this._context.shared.global.quit()
+  }
+}

--- a/src/main/shards/app-common/index.ts
+++ b/src/main/shards/app-common/index.ts
@@ -1,10 +1,7 @@
-import elevateExecutablePath from '@resources/elevate.exe?asset&asarUnpack'
 import { IAkariShardInitDispose, Shard, SharedGlobalShard } from '@shared/akari-shard'
 import { APP_THEME_VALUES } from '@shared/types/app-theme'
 import { app, clipboard, shell } from 'electron'
-import { exec } from 'node:child_process'
 import os from 'node:os'
-import { promisify } from 'node:util'
 import { z } from 'zod'
 
 import { AkariProtocolMain } from '../akari-protocol'
@@ -13,14 +10,13 @@ import { AkariLogger, LoggerFactoryMain } from '../logger-factory'
 import { MobxUtilsMain } from '../mobx-utils'
 import { SettingFactoryMain } from '../setting-factory'
 import { SetterSettingService } from '../setting-factory/setter-setting-service'
+import { AdministratorRelaunchExecutor } from './administrator-relaunch-executor'
 import { APP_COMMON_MAIN_NAMESPACE, type AppCommonMainContext } from './context'
 import { AppCommonDiagnosticsController } from './diagnostics-controller'
 import { AppCommonIpcHandlers } from './ipc-handlers'
 import { RendererLinkProtocol } from './renderer-link-protocol'
 import { AppCommonSettings, AppCommonState } from './state'
 import { AppCommonThemeController } from './theme-controller'
-
-const execAsync = promisify(exec)
 
 /**
  * 一些不知道如何分类的通用功能, 可以放到这里
@@ -39,6 +35,7 @@ export class AppCommonMain implements IAkariShardInitDispose {
   private readonly _themeController: AppCommonThemeController
   private readonly _rendererLinkProtocol: RendererLinkProtocol
   private readonly _diagnosticsController: AppCommonDiagnosticsController
+  private readonly _administratorRelaunchExecutor: AdministratorRelaunchExecutor
 
   constructor(
     private readonly _shared: SharedGlobalShard,
@@ -99,6 +96,7 @@ export class AppCommonMain implements IAkariShardInitDispose {
     this._themeController = new AppCommonThemeController(this._context)
     this._rendererLinkProtocol = new RendererLinkProtocol(this._context)
     this._diagnosticsController = new AppCommonDiagnosticsController(this._context)
+    this._administratorRelaunchExecutor = new AdministratorRelaunchExecutor(this._context)
   }
 
   private _getSystemLocale() {
@@ -141,14 +139,8 @@ export class AppCommonMain implements IAkariShardInitDispose {
     return clipboard.readText()
   }
 
-  async relaunchAsAdministrator() {
-    const appPath = process.execPath
-
-    await execAsync(`"${elevateExecutablePath}" "${appPath}"`, {
-      shell: 'cmd'
-    })
-
-    app.exit()
+  relaunchAsAdministrator() {
+    return this._administratorRelaunchExecutor.relaunch()
   }
 
   async getRuntimeInfo() {

--- a/src/main/shards/window-manager/main-window/window.test.ts
+++ b/src/main/shards/window-manager/main-window/window.test.ts
@@ -1,3 +1,4 @@
+import { wasRelaunchedAsAdministrator } from '@main/administrator-relaunch'
 import { BrowserWindow } from 'electron'
 import { reaction } from 'mobx'
 import { EventEmitter } from 'node:events'
@@ -9,6 +10,9 @@ import { repositionWindowIfInvisible } from '../window-position-service'
 import { AkariMainWindow } from './window'
 
 vi.mock('@resources/LA_ICON.ico?asset&asarUnpack', () => ({ default: 'akari-icon.ico' }))
+vi.mock('@main/administrator-relaunch', () => ({
+  wasRelaunchedAsAdministrator: vi.fn(() => false)
+}))
 vi.mock('@electron-toolkit/utils', () => ({ is: { dev: false } }))
 vi.mock('@main/i18n', () => ({ i18next: { t: (key: string) => key } }))
 vi.mock('../window-position-service', () => ({ repositionWindowIfInvisible: vi.fn() }))
@@ -183,6 +187,31 @@ afterEach(async () => {
   await Promise.all(windows.splice(0).map((window) => window.onDispose()))
   vi.useRealTimers()
   vi.clearAllMocks()
+  vi.mocked(wasRelaunchedAsAdministrator).mockReturnValue(false)
+})
+
+describe('elevated main-window startup', () => {
+  it('recovers from SW_HIDE even when Chromium incorrectly reports visible, preserving maximization', async () => {
+    vi.mocked(wasRelaunchedAsAdministrator).mockReturnValue(true)
+    const { mainWindow, nativeWindow } = await launch(new Map([[maximizedKey, true]]), false)
+    let hwndVisible = false
+    let hiddenAgain = false
+    vi.spyOn(nativeWindow, 'hide').mockImplementation(() => {
+      hiddenAgain = true
+      nativeWindow.visible = false
+      nativeWindow.emit('hide')
+    })
+    vi.spyOn(nativeWindow, 'show').mockImplementation(() => {
+      nativeWindow.visible = true
+      hwndVisible = hiddenAgain
+      nativeWindow.emit('show')
+    })
+    nativeWindow.emit('ready-to-show')
+    await Promise.resolve()
+    expect(hwndVisible).toBe(true)
+    expect(mainWindow.state.show).toBe(true)
+    expect(nativeWindow.isMaximized()).toBe(true)
+  })
 })
 
 describe('main window maximized-state persistence', () => {

--- a/src/main/shards/window-manager/main-window/window.ts
+++ b/src/main/shards/window-manager/main-window/window.ts
@@ -1,3 +1,4 @@
+import { wasRelaunchedAsAdministrator } from '@main/administrator-relaunch'
 import icon from '@resources/LA_ICON.ico?asset&asarUnpack'
 import type { BackgroundMaterialSetting } from '@shared/shards/window-manager'
 import { Event } from 'electron'
@@ -68,6 +69,13 @@ export class AkariMainWindow extends BaseAkariWindow<MainWindowState, MainWindow
       (ready) => {
         if (ready) {
           this.showOrRestore()
+          if (wasRelaunchedAsAdministrator()) {
+            // The bundled elevate.exe starts its target with SW_HIDE. Chromium can report a
+            // visible window after the first show even though the HWND remains hidden. Reset
+            // both states before showing again; another show/focus alone does not recover it.
+            this.hide()
+            this.showOrRestore()
+          }
         }
       }
     )

--- a/src/renderer-shared/shards/app-common/administrator-relaunch-controller.ts
+++ b/src/renderer-shared/shards/app-common/administrator-relaunch-controller.ts
@@ -1,0 +1,26 @@
+import { useTranslation } from 'i18next-vue'
+import { useMessage } from 'naive-ui'
+
+import { AppCommonRenderer } from '.'
+import { useInstance } from '..'
+import { useAppCommonStore } from './store'
+
+export function useAdministratorRelaunch() {
+  const appCommon = useInstance(AppCommonRenderer)
+  const store = useAppCommonStore()
+  const message = useMessage()
+  const { t } = useTranslation()
+
+  return async () => {
+    if (!store.isWindows) {
+      return false
+    }
+    try {
+      await appCommon.relaunchAsAdministrator()
+    } catch {
+      message.warning(t('notifications.simple.administratorRelaunchFailed'))
+    }
+    // Keep the dialog available for retry if elevation was cancelled or failed.
+    return false
+  }
+}

--- a/src/renderer/src-main-window/shards/simple-notifications/system-warning-dialogs.test.ts
+++ b/src/renderer/src-main-window/shards/simple-notifications/system-warning-dialogs.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope } from 'vue'
+
+import {
+  watchAskUserToRunAsAdministrator,
+  watchCannotGetUxCommandLine
+} from './system-warning-dialogs'
+
+const mocks = vi.hoisted(() => ({
+  app: { isWindows: true, isElevated: false },
+  ux: { settings: { useWmi: false }, hasClientButNoCommandLine: true },
+  relaunch: vi.fn(),
+  warning: vi.fn(),
+  message: vi.fn(),
+  destroy: vi.fn()
+}))
+vi.mock('@renderer-shared/shards', () => ({
+  useInstance: () => ({ relaunchAsAdministrator: mocks.relaunch })
+}))
+vi.mock('@renderer-shared/shards/app-common', () => ({ AppCommonRenderer: class {} }))
+vi.mock('@renderer-shared/shards/app-common/store', () => ({ useAppCommonStore: () => mocks.app }))
+vi.mock('@renderer-shared/shards/league-client-ux/store', () => ({
+  useLeagueClientUxStore: () => mocks.ux
+}))
+vi.mock('@renderer-shared/shards/league-client/store', () => ({
+  useLeagueClientStore: () => ({ isDisconnected: true })
+}))
+vi.mock('@renderer-shared/shards/akari-navigation', () => ({ useAkariNavigation: vi.fn() }))
+vi.mock('@main-window/settings-navigation', () => ({ navigateToSetting: vi.fn() }))
+vi.mock('i18next-vue', () => ({ useTranslation: () => ({ t: (key: string) => key }) }))
+vi.mock('naive-ui', () => ({
+  NCheckbox: {},
+  useDialog: () => ({ warning: mocks.warning }),
+  useMessage: () => ({ warning: mocks.message })
+}))
+
+let scope = effectScope()
+beforeEach(() => {
+  scope = effectScope()
+  mocks.app.isWindows = true
+  mocks.app.isElevated = false
+  mocks.ux.settings.useWmi = false
+  vi.resetAllMocks()
+  mocks.warning.mockImplementation(() => ({ destroy: mocks.destroy }))
+  mocks.relaunch.mockResolvedValue(undefined)
+})
+afterEach(() => scope.stop())
+
+describe('Windows elevation dialogs', () => {
+  it('does not offer either Windows-only dialog on macOS, even with WMI enabled', () => {
+    mocks.app.isWindows = false
+    mocks.ux.settings.useWmi = true
+    scope.run(() => {
+      watchAskUserToRunAsAdministrator()
+      watchCannotGetUxCommandLine()
+    })
+    expect(mocks.warning).not.toHaveBeenCalled()
+    expect(mocks.relaunch).not.toHaveBeenCalled()
+  })
+
+  it('the non-admin connection warning actually restarts; an already elevated confirmation does not', async () => {
+    scope.run(watchCannotGetUxCommandLine)
+    await mocks.warning.mock.calls[0][0].onPositiveClick()
+    expect(mocks.relaunch).toHaveBeenCalledTimes(1)
+    mocks.app.isElevated = true
+    scope.run(watchCannotGetUxCommandLine)
+    await mocks.warning.mock.calls[1][0].onPositiveClick()
+    expect(mocks.relaunch).toHaveBeenCalledTimes(1)
+    expect(mocks.destroy).toHaveBeenCalledTimes(1)
+  })
+
+  it('handles a rejected elevation without an unhandled promise, and keeps the dialog available to retry', async () => {
+    mocks.ux.settings.useWmi = true
+    mocks.relaunch.mockRejectedValueOnce(new Error('UAC cancelled'))
+    scope.run(watchAskUserToRunAsAdministrator)
+    const positiveClick = mocks.warning.mock.calls[0][0].onPositiveClick
+    await expect(positiveClick()).resolves.toBe(false)
+    expect(mocks.message).toHaveBeenCalledTimes(1)
+    expect(mocks.destroy).not.toHaveBeenCalled()
+    await positiveClick()
+    expect(mocks.relaunch).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/src-main-window/shards/simple-notifications/system-warning-dialogs.tsx
+++ b/src/renderer/src-main-window/shards/simple-notifications/system-warning-dialogs.tsx
@@ -1,8 +1,6 @@
-import { useInstance } from '@renderer-shared/shards'
 import { useAkariNavigation } from '@renderer-shared/shards/akari-navigation'
-import { AppCommonRenderer } from '@renderer-shared/shards/app-common'
+import { useAdministratorRelaunch } from '@renderer-shared/shards/app-common/administrator-relaunch-controller'
 import { useAppCommonStore } from '@renderer-shared/shards/app-common/store'
-import { LeagueClientUxRenderer } from '@renderer-shared/shards/league-client-ux'
 import { useLeagueClientUxStore } from '@renderer-shared/shards/league-client-ux/store'
 import { useLeagueClientStore } from '@renderer-shared/shards/league-client/store'
 import { useSelfUpdateStore } from '@renderer-shared/shards/self-update/store'
@@ -29,10 +27,12 @@ export function watchAskUserToRunAsAdministrator() {
     keyPrefix: 'notifications.simple.wmiRequiresAdministrator'
   })
 
-  const appCommon = useInstance(AppCommonRenderer)
+  const relaunchAsAdministrator = useAdministratorRelaunch()
 
   const shouldAsk = computed(() => {
-    return leagueClientUxStore.settings.useWmi && !appCommonStore.isElevated
+    return (
+      appCommonStore.isWindows && leagueClientUxStore.settings.useWmi && !appCommonStore.isElevated
+    )
   })
 
   watch(
@@ -47,9 +47,7 @@ export function watchAskUserToRunAsAdministrator() {
           onNegativeClick: () => {
             dialogReactive.destroy()
           },
-          onPositiveClick: () => {
-            appCommon.relaunchAsAdministrator()
-          }
+          onPositiveClick: relaunchAsAdministrator
         })
       }
     },
@@ -59,7 +57,6 @@ export function watchAskUserToRunAsAdministrator() {
 
 export function watchCannotGetUxCommandLine() {
   const leagueClientStore = useLeagueClientStore()
-  const leagueClientUx = useInstance(LeagueClientUxRenderer)
   const leagueClientUxStore = useLeagueClientUxStore()
   const appCommonStore = useAppCommonStore()
   const dialog = useDialog()
@@ -67,7 +64,7 @@ export function watchCannotGetUxCommandLine() {
     keyPrefix: 'notifications.simple.cannotGetUxCommandLine'
   })
 
-  const appCommon = useInstance(AppCommonRenderer)
+  const relaunchAsAdministrator = useAdministratorRelaunch()
 
   let dialogReactive: DialogReactive | null = null
   watch(
@@ -77,7 +74,7 @@ export function watchCannotGetUxCommandLine() {
         leagueClientStore.isDisconnected /* 在退出 leagueClientUx 后，leagueClient 仍然会短暂停留并处理善后工作，考虑仅限未连接才会触发此提示 */
     ],
     ([hasClientButNoCommandLine, isDisconnected]) => {
-      if (hasClientButNoCommandLine && isDisconnected) {
+      if (appCommonStore.isWindows && hasClientButNoCommandLine && isDisconnected) {
         if (leagueClientUxStore.settings.useWmi) {
           dialogReactive = dialog.warning({
             style: { width: '600px' },
@@ -103,13 +100,11 @@ export function watchCannotGetUxCommandLine() {
             ? t('withAdminPositiveText')
             : t('noAdminPositiveText'),
           onPositiveClick: () => {
-            if (appCommonStore.isElevated) {
-              leagueClientUx.setUseWmi(true).then(() => {
-                appCommon.relaunchAsAdministrator()
-              })
-            } else {
-              dialogReactive?.destroy()
+            if (!appCommonStore.isElevated) {
+              return relaunchAsAdministrator()
             }
+            dialogReactive?.destroy()
+            return true
           }
         })
       } else {

--- a/src/renderer/src-main-window/views/test/KeyboardShortcutsTest.vue
+++ b/src/renderer/src-main-window/views/test/KeyboardShortcutsTest.vue
@@ -228,7 +228,7 @@
 
 <script setup lang="ts">
 import { KeyboardShortcutsRenderer } from '@renderer-shared/shards/keyboard-shortcut'
-import { AppCommonRenderer } from '@renderer-shared/shards/app-common'
+import { useAdministratorRelaunch } from '@renderer-shared/shards/app-common/administrator-relaunch-controller'
 import { useAppCommonStore } from '@renderer-shared/shards/app-common/store'
 import { useInstance } from '@renderer-shared/shards'
 import ShortcutSelector from '@main-window/components/ShortcutSelector.vue'
@@ -244,7 +244,7 @@ import { computed, onActivated, onBeforeUnmount, onDeactivated, ref, watch } fro
 
 const as = useAppCommonStore()
 const kbd = useInstance(KeyboardShortcutsRenderer)
-const app = useInstance(AppCommonRenderer)
+const relaunchAsAdmin = useAdministratorRelaunch()
 
 const debugState = ref<KeyboardShortcutsDebugState | null>(null)
 const lastShortcut = ref<ShortcutDetails | null>(null)
@@ -655,10 +655,6 @@ onBeforeUnmount(() => {
   pause()
   clearDebugStatefulShortcut()
 })
-
-const relaunchAsAdmin = () => {
-  app.relaunchAsAdministrator()
-}
 </script>
 
 <style scoped>

--- a/src/shared/i18n/en/renderer/notifications.yaml
+++ b/src/shared/i18n/en/renderer/notifications.yaml
@@ -14,6 +14,7 @@ notifications:
     ignoreThisVersion: Ignore This Version
     noUpdate: No updates
   simple:
+    administratorRelaunchFailed: Elevation was cancelled or the launch failed. This app is still running. Retry, or close it and choose “Run as administrator”. Check the logs if it still fails.
     elevatedStartup:
       title: Running as administrator
       content: $t(common:appName) is currently running with elevated privileges

--- a/src/shared/i18n/zh-CN/renderer/notifications.yaml
+++ b/src/shared/i18n/zh-CN/renderer/notifications.yaml
@@ -14,6 +14,7 @@ notifications:
     ignoreThisVersion: 忽略此版本
     noUpdate: 无更新
   simple:
+    administratorRelaunchFailed: 提权已取消或启动失败，当前应用未退出。可重试，或关闭应用后右键“以管理员身份运行”；若仍失败请查看日志。
     elevatedStartup:
       title: 正在以管理员身份运行
       content: $t(common:appName) 当前正在以高权限运行


### PR DESCRIPTION
### 改动说明

- 继续使用 `elevate.exe` 执行 Windows 提权重启。
- 等待旧进程退出后，再初始化提权后的实例。
- 修复提权后窗口可能不可见的问题。
- 处理取消提权和启动失败的情况。
- 为非 Windows 平台屏蔽管理员重启入口及执行路径。

### 验证情况

- 在 Windows 11 ARM 虚拟机中验证了完整应用的提权重启、窗口恢复、取消提权、失败重试和托盘恢复。
- 验证了 macOS 平台保护。
- 自动化测试、类型检查和构建通过。